### PR TITLE
Removed restriction on Pydantic after numpydantic update.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "openmdao<=3.37.0",
     "om-aviary",
     "json-numpy",
-    "pydantic==2.10.6",
+    "pydantic",
     "h5py",
     "numpydantic",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "json-numpy",
     "pydantic",
     "h5py",
-    "numpydantic",
+    "numpydantic>=1.6.9",
 ]
 
 dynamic = ["version", "scripts"]


### PR DESCRIPTION
Closes #36. The developer of the Numpydantic library updated the library which fixed the issues we were seeing with the newest version of Pydantic. 