### PR TITLE
feat: add EvaluatorOpenMdaoComponent to standard_evaluator.components

### DIFF
--- a/.kiro/specs/openmdao-component-migration/.config.kiro
+++ b/.kiro/specs/openmdao-component-migration/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "67862a7e-0fd1-45a6-b465-c6ac2a0a6007", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/openmdao-component-migration/design.md
+++ b/.kiro/specs/openmdao-component-migration/design.md
@@ -1,0 +1,249 @@
+# Design Document
+
+## Overview
+
+This design describes the migration of `EvaluatorOpenMdaoComponent` from the boeing-standard-evaluator (bse) library into the standard-evaluator (se) library. The component wraps any `Evaluator` instance as an OpenMDAO `ExplicitComponent`, bridging the se evaluation API with the OpenMDAO data flow.
+
+The key architectural change is replacing the legacy dict-based `problem` API (`self.eval.problem["variables"]`) with the pydantic `OptProblem` API (`self.eval.opt_problem.variables`). This means:
+- Variable iteration switches from dict key/value pairs to a list of typed pydantic `Variable` objects
+- Variable metadata (bounds, default, shift, scale) are accessed as attributes rather than dict keys
+- Response metadata follows the same pattern
+
+The component will be placed in a new `standard_evaluator.components` subpackage, keeping component logic separate from core evaluator logic.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[OpenMDAO Problem] --> B[EvaluatorOpenMdaoComponent]
+    B --> C[Evaluator.__call__]
+    C --> D[pandas DataFrame]
+    
+    subgraph "Component Lifecycle"
+        E[__init__] --> F[initialize]
+        F --> G[setup]
+        G --> H[compute]
+    end
+    
+    subgraph "Data Flow in compute()"
+        I[OpenMDAO inputs] --> J[Build DataFrame]
+        J --> K[Call Evaluator]
+        K --> L[Extract responses]
+        L --> M[Set OpenMDAO outputs]
+    end
+```
+
+The component follows the standard OpenMDAO `ExplicitComponent` lifecycle:
+1. `__init__`: Store a deep copy of the evaluator (or reconstruct from serialized dict)
+2. `initialize`: Declare `evaluator_options` OpenMDAO option if the evaluator is serializable
+3. `setup`: Map `opt_problem.variables` → OpenMDAO inputs, `opt_problem.responses` → OpenMDAO outputs
+4. `compute`: Convert inputs → DataFrame, call evaluator, extract responses → outputs
+
+## Components and Interfaces
+
+### Module Structure
+
+```
+standard_evaluator/
+├── components/
+│   ├── __init__.py              # exports EvaluatorOpenMdaoComponent
+│   └── evaluator_om_component.py  # component implementation
+├── evaluators/
+│   └── abstract_evaluator.py   # Evaluator base class
+├── surrogate_models/
+│   └── abstract_model.py       # SurrogateModel with from_dict/to_dict
+└── problem.py                  # OptProblem, Variable types
+```
+
+### Class Interface
+
+```python
+class EvaluatorOpenMdaoComponent(om.ExplicitComponent):
+    """Expose a standard Evaluator as an OpenMDAO ExplicitComponent."""
+    
+    def __init__(self, evaluator: Evaluator = None, **kwargs: dict):
+        """Initialize with evaluator instance or reconstruct from evaluator_options."""
+        ...
+    
+    def initialize(self) -> None:
+        """Declare evaluator_options option if evaluator supports to_dict()."""
+        ...
+    
+    def setup(self) -> None:
+        """Map OptProblem variables to inputs, responses to outputs."""
+        ...
+    
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None) -> None:
+        """Build DataFrame from inputs, call evaluator, extract responses."""
+        ...
+```
+
+### Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| `openmdao` | Parent class `om.ExplicitComponent` |
+| `pandas` | DataFrame construction for evaluator calls |
+| `copy` | Deep copy of evaluator in constructor |
+| `numpy` | Infinity checks for bounds |
+
+### Key Interactions
+
+- **Evaluator → Component**: The component reads `evaluator.opt_problem.variables` and `evaluator.opt_problem.responses` to discover input/output metadata.
+- **Component → Evaluator**: The `compute()` method calls `self.eval(data_frame)` where the evaluator modifies the DataFrame in place.
+- **SurrogateModel → Component**: The fallback constructor path uses `SurrogateModel.from_dict(evaluator_options)` to reconstruct a serializable evaluator.
+
+## Data Models
+
+### Variable Access Patterns
+
+The se `Variable` pydantic models (FloatVariable, IntVariable, ArrayVariable, CategoricalVariable) provide:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `.name` | `str` | Variable identifier used as OpenMDAO input/output name |
+| `.bounds` | `Tuple[float, float]` | Lower and upper bounds; `-inf`/`+inf` for unbounded |
+| `.default` | `float \| None` | Default value; `None` means calculate from bounds midpoint |
+| `.shift` | `float` | Shift for scaling (default 0.0) |
+| `.scale` | `float` | Scale factor (default 1.0, cannot be 0) |
+
+### OpenMDAO Mapping
+
+**Inputs** (from `opt_problem.variables`):
+```python
+add_input(name=var.name, val=default_value)
+```
+Where `default_value` is `var.default` if not None, otherwise calculated from bounds midpoint.
+
+**Outputs** (from `opt_problem.responses`):
+```python
+add_output(
+    name=resp.name,
+    lower=lower_bound,   # None if -inf
+    upper=upper_bound,   # None if +inf
+    ref0=-resp.shift,
+    ref=(1.0 / resp.scale) + ref0,
+    val=0.0
+)
+```
+
+### DataFrame Construction in compute()
+
+```python
+input_dict = {var_name: inputs[var_name] for var_name in self.eval.inputs}
+data_frame = pd.DataFrame(data=input_dict)
+self.eval(data_frame)  # modifies in-place
+for response in self.eval.outputs:
+    outputs[response] = data_frame[response].iloc[0]
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Deep Copy Isolation
+
+*For any* Evaluator instance used to construct the component, mutating the original Evaluator's `opt_problem` after construction SHALL NOT affect the component's stored evaluator. The component's `eval` attribute remains an independent copy.
+
+**Validates: Requirements 2.1**
+
+### Property 2: Serialization Option Round Trip
+
+*For any* Evaluator that has a `to_dict` method, after component initialization and the `initialize` lifecycle method, the component's `options["evaluator_options"]` SHALL equal the result of calling `to_dict()` on the original evaluator.
+
+**Validates: Requirements 4.2**
+
+### Property 3: Variable-to-Input Default Mapping
+
+*For any* Variable in the evaluator's `opt_problem.variables`, the corresponding OpenMDAO input default value SHALL be `variable.default` if `variable.default` is not None, otherwise it SHALL be the midpoint of the variable's bounds `(lower + upper) / 2`.
+
+**Validates: Requirements 5.2, 5.3, 5.4, 5.5**
+
+### Property 4: Response-to-Output Bounds Mapping
+
+*For any* response Variable in `opt_problem.responses`, the OpenMDAO output bounds SHALL be: the actual bound value when finite, or `None` when the bound is infinite (`-inf` for lower, `+inf` for upper).
+
+**Validates: Requirements 6.3, 6.4**
+
+### Property 5: Response Scaling Formula
+
+*For any* response Variable with `shift` and `scale` values (where `scale != 0`), the OpenMDAO output `ref0` SHALL equal `-shift` and `ref` SHALL equal `(1.0 / scale) + ref0`.
+
+**Validates: Requirements 6.5**
+
+### Property 6: Compute Round Trip
+
+*For any* TestEvaluator from `standard_evaluator.evaluators.test`, when the component is constructed, set up in an OpenMDAO problem, and `run_model()` is called with default inputs, the output values for every response SHALL match (within relative tolerance 1e-10) the values obtained by invoking the same evaluator directly with a DataFrame of the same default inputs.
+
+**Validates: Requirements 7.1, 7.2, 7.3, 8.2, 8.3**
+
+## Error Handling
+
+| Condition | Error Type | Message |
+|---|---|---|
+| First positional arg is not an Evaluator | `TypeError` | Indicates expected type is `Evaluator` |
+| No evaluator and no `evaluator_options` in kwargs | `AttributeError` | "No evaluator and no evaluator_options defined." |
+| `SurrogateModel.from_dict()` fails | Propagated exception | Whatever `from_dict()` raises |
+| `discrete_inputs` is not None | `ValueError` | "At this point we do not yet support discrete inputs" |
+| `discrete_outputs` is not None | `ValueError` | "At this point we do not yet support discrete outputs" |
+| Response scale is 0.0 | `ValueError` | "Response {name} has a scale value of 0.0" |
+| Kwarg conflicts with internal attribute (e.g., 'eval') | Clear error | Raised before calling parent constructor |
+| Evaluator raises during compute | Propagated exception | Unmodified from evaluator |
+
+**Design Decisions:**
+- Errors are raised eagerly (fail-fast) during construction or setup rather than deferring to compute time
+- The component does not catch evaluator exceptions — they propagate naturally so OpenMDAO's error reporting works correctly
+- Discrete variable support is explicitly rejected with informative messages since the evaluator API is DataFrame-based (continuous only)
+
+## Testing Strategy
+
+### Test Framework
+
+- **Unit/Integration tests**: `pytest`
+- **Property-based tests**: `hypothesis` (already a test dependency in pyproject.toml)
+- **Minimum iterations**: 100 per property test
+
+### Property-Based Tests
+
+Each correctness property maps to one `hypothesis`-powered test:
+
+1. **Deep Copy Isolation** — Generate evaluators with varying opt_problem structures, construct component, mutate original, verify isolation
+2. **Serialization Option Round Trip** — Use SurrogateModel instances, verify options match to_dict()
+3. **Variable-to-Input Default Mapping** — Generate FloatVariables with various defaults/bounds combinations, verify correct input defaults
+4. **Response-to-Output Bounds Mapping** — Generate response Variables with mix of finite/infinite bounds, verify OpenMDAO output bounds
+5. **Response Scaling Formula** — Generate response Variables with arbitrary shift/scale (scale ≠ 0), verify ref0 and ref computation
+6. **Compute Round Trip** — Parametrize over TestEvaluators, verify component outputs match direct evaluator call
+
+### Example-Based / Unit Tests
+
+- Import resolution tests (Requirements 1.1–1.3)
+- TypeError when non-Evaluator passed (Requirement 2.4)
+- AttributeError when no evaluator or options (Requirement 3.2)
+- ValueError for discrete inputs/outputs (Requirements 7.4, 7.5)
+- ValueError for scale=0.0 response (Requirement 6.6)
+- Kwarg conflict detection (Requirement 2.2)
+- Exception propagation from SurrogateModel.from_dict (Requirement 3.3)
+- Exception propagation from evaluator during compute (Requirement 7.6)
+
+### Integration Tests
+
+- End-to-end with HS100 evaluator (Requirement 8.1)
+- SurrogateModel.from_dict reconstruction path (Requirement 3.1)
+
+### Tag Format
+
+Each property test will include a comment:
+```python
+# Feature: openmdao-component-migration, Property {N}: {property_text}
+```
+
+### Test File Location
+
+```
+tests/
+└── components/
+    ├── __init__.py
+    ├── test_evaluator_om_component.py       # unit + integration tests
+    └── test_pbt_evaluator_om_component.py   # property-based tests
+```
+

--- a/.kiro/specs/openmdao-component-migration/requirements.md
+++ b/.kiro/specs/openmdao-component-migration/requirements.md
@@ -1,0 +1,107 @@
+# Requirements Document
+
+## Introduction
+
+This document defines the requirements for migrating the `EvaluatorOpenMdaoComponent` class from the boeing-standard-evaluator (bse) library into the standard-evaluator (se) library. The component wraps a standard Evaluator so it can be used as an OpenMDAO ExplicitComponent, mapping evaluator variables to OpenMDAO inputs and evaluator responses to OpenMDAO outputs. The migration adapts the component from the legacy dict-based `problem` API to the pydantic `OptProblem` API used in se.
+
+## Glossary
+
+- **Component**: The `EvaluatorOpenMdaoComponent` class, an OpenMDAO `ExplicitComponent` that wraps a standard Evaluator.
+- **Evaluator**: An instance of `standard_evaluator.evaluators.abstract_evaluator.Evaluator`, the abstract base class for all evaluators in se.
+- **OptProblem**: A pydantic model (`standard_evaluator.problem.OptProblem`) defining the optimization problem with typed `variables` and `responses` lists.
+- **Variable**: A pydantic model (`standard_evaluator.problem.FloatVariable` or similar) representing an input or output variable with `.name`, `.bounds`, `.default`, `.shift`, `.scale` attributes.
+- **SurrogateModel**: A class in `standard_evaluator.surrogate_models.abstract_model` that extends Evaluator and provides `from_dict()` and `to_dict()` methods for serialization.
+- **OpenMDAO_Input**: An OpenMDAO input variable declared via `add_input()` during component setup.
+- **OpenMDAO_Output**: An OpenMDAO output variable declared via `add_output()` during component setup.
+
+## Requirements
+
+### Requirement 1: Component Module Location
+
+**User Story:** As a developer, I want the EvaluatorOpenMdaoComponent to live in a `components/` subdirectory within the se package, so that the project structure mirrors the bse layout and keeps component logic separate from core evaluator logic.
+
+#### Acceptance Criteria
+
+1. THE Component SHALL be defined in the module `standard_evaluator.components.evaluator_om_component`.
+2. THE `standard_evaluator.components` package SHALL export `EvaluatorOpenMdaoComponent` via its `__init__.py` such that `from standard_evaluator.components import EvaluatorOpenMdaoComponent` resolves without error. IF the component is not defined in the specified module, THEN the import SHALL fail.
+3. WHEN `standard_evaluator.components` is imported, THE package SHALL include `EvaluatorOpenMdaoComponent` in its `__all__` list.
+
+### Requirement 2: Constructor with Evaluator Instance
+
+**User Story:** As a developer, I want to construct the component by passing an Evaluator instance directly, so that I can wrap any evaluator for use in OpenMDAO.
+
+#### Acceptance Criteria
+
+1. WHEN an Evaluator instance is provided as the first positional argument, THE Component SHALL store a deep copy of the Evaluator in its `eval` attribute such that subsequent mutations to the original Evaluator do not affect the stored copy.
+2. WHEN an Evaluator instance is provided, THE Component SHALL detect any keyword argument that conflicts with an internal Component attribute (e.g., 'eval') and raise a clear error before calling the parent constructor. All non-conflicting keyword arguments SHALL be passed to the OpenMDAO ExplicitComponent constructor without modification.
+3. THE Component SHALL accept any concrete subclass of `standard_evaluator.evaluators.abstract_evaluator.Evaluator` as the evaluator argument.
+4. IF the first positional argument is provided and is not an instance of `standard_evaluator.evaluators.abstract_evaluator.Evaluator`, THEN THE Component SHALL raise a `TypeError` with a message indicating the expected type.
+
+### Requirement 3: Constructor Fallback via SurrogateModel.from_dict
+
+**User Story:** As a developer, I want the component to reconstruct an evaluator from a serialized dictionary when no evaluator instance is provided, so that models can be deserialized from stored configurations.
+
+#### Acceptance Criteria
+
+1. WHEN the `evaluator` argument is None AND kwargs contain an `evaluator_options` key with a dictionary value, THE Component SHALL create an Evaluator by calling `SurrogateModel.from_dict()` with the value of `evaluator_options` and store a deep copy of the resulting Evaluator.
+2. WHEN the `evaluator` argument is None AND kwargs do not contain an `evaluator_options` key, THE Component SHALL raise an `AttributeError` with a message indicating that no evaluator and no evaluator_options were defined.
+3. IF the `evaluator` argument is None AND `SurrogateModel.from_dict()` raises an exception due to an invalid `evaluator_options` value (e.g., not a dictionary, missing required keys, or unrecognized model type), THEN THE Component SHALL allow the exception to propagate to the caller without suppression.
+
+### Requirement 4: Initialize Method for Serialization
+
+**User Story:** As a developer, I want the component to store evaluator serialization data in OpenMDAO options when the evaluator supports `to_dict()`, so that the component can be reconstructed from saved OpenMDAO configurations.
+
+#### Acceptance Criteria
+
+1. WHEN the stored Evaluator has a `to_dict` method, THE Component SHALL declare an `evaluator_options` option of type `dict` specifically during the `initialize` lifecycle method (not at any other point in the lifecycle).
+2. WHEN the stored Evaluator has a `to_dict` method, THE Component SHALL set the `evaluator_options` option value to the result of calling `to_dict()` on the Evaluator.
+3. WHEN the stored Evaluator does not have a `to_dict` method, THE Component SHALL not declare the `evaluator_options` option.
+
+### Requirement 5: Setup Maps Variables to OpenMDAO Inputs
+
+**User Story:** As a developer, I want the component to automatically create OpenMDAO inputs from the evaluator's OptProblem variables, so that the variable definitions flow through without manual configuration.
+
+#### Acceptance Criteria
+
+1. WHEN setup is called, THE Component SHALL add one OpenMDAO input for each Variable in `evaluator.opt_problem.variables`.
+2. WHEN setup is called, THE Component SHALL use the Variable `.name` attribute as the OpenMDAO input name.
+3. IF the Variable `.default` attribute is not None, THEN THE Component SHALL use the Variable `.default` attribute as the OpenMDAO input default value, even if the default value falls outside the variable's defined bounds.
+4. IF the Variable `.default` attribute is None, THEN THE Component SHALL calculate the default from the Variable bounds midpoint before using it as the OpenMDAO input default value.
+5. IF the Variable has both a non-None `.default` value and bounds, THEN THE Component SHALL use the explicit `.default` value, ignoring bounds for default calculation.
+
+### Requirement 6: Setup Maps Responses to OpenMDAO Outputs
+
+**User Story:** As a developer, I want the component to automatically create OpenMDAO outputs from the evaluator's OptProblem responses with proper bounds and scaling, so that optimizer integration works correctly.
+
+#### Acceptance Criteria
+
+1. WHEN setup is called, THE Component SHALL call `add_output` once for each Variable in `evaluator.opt_problem.responses`, resulting in one OpenMDAO output per response Variable.
+2. WHEN setup is called, THE Component SHALL use the response Variable `.name` attribute as the OpenMDAO output name passed to `add_output`.
+3. WHEN a response Variable has bounds where both lower and upper values are finite (not `-inf` or `+inf`), THE Component SHALL set the OpenMDAO output `lower` parameter to the first element of the bounds tuple and the `upper` parameter to the second element of the bounds tuple.
+4. IF a response Variable has bounds where either value is non-finite (`-inf` or `+inf`), THEN THE Component SHALL pass `None` for the corresponding `lower` or `upper` parameter of the OpenMDAO output.
+5. WHEN a response Variable has shift and scale values, THE Component SHALL always compute `ref0 = -shift` and `ref = (1.0 / scale) + ref0` and pass these as the `ref0` and `ref` parameters of the OpenMDAO output, regardless of whether the values are defaults (shift=0.0, scale=1.0) or not.
+6. IF a response Variable has a scale value of 0.0, THEN THE Component SHALL raise a `ValueError` with a message indicating which response has a scale value of 0.0.
+7. THE Component SHALL set the OpenMDAO output default value (`val` parameter) to 0.0 for all response outputs.
+
+### Requirement 7: Compute Evaluates via the Evaluator
+
+**User Story:** As a developer, I want the compute method to convert OpenMDAO inputs into a DataFrame, call the evaluator, and extract responses back to OpenMDAO outputs, so that the evaluator executes within the OpenMDAO data flow.
+
+#### Acceptance Criteria
+
+1. WHEN compute is called, THE Component SHALL construct a single-row pandas DataFrame whose columns correspond to the evaluator's input names and whose values are the current OpenMDAO input values for those names.
+2. WHEN compute is called, THE Component SHALL invoke the Evaluator as a callable, passing the constructed DataFrame as the argument.
+3. WHEN compute is called, THE Component SHALL extract the scalar value at row index 0 for each response column from the evaluated DataFrame and assign it to the corresponding OpenMDAO output.
+4. WHEN compute is called, THE Component SHALL first check for discrete inputs and outputs before performing any computation. IF discrete_inputs is not None, THEN THE Component SHALL raise a `ValueError` stating that discrete inputs are not supported.
+5. WHEN compute is called, THE Component SHALL first check for discrete inputs and outputs before performing any computation. IF discrete_outputs is not None, THEN THE Component SHALL raise a `ValueError` stating that discrete outputs are not supported.
+6. IF the Evaluator raises an exception during invocation, THEN THE Component SHALL propagate the exception to the caller without modification.
+
+### Requirement 8: Integration with Test Evaluators
+
+**User Story:** As a developer, I want to verify the component works end-to-end with se's existing test evaluators, so that the migration is validated against known expected outputs.
+
+#### Acceptance Criteria
+
+1. WHEN the Component wraps an HS100 evaluator from `standard_evaluator.evaluators.test` and `problem.run_model()` is called, THE Component SHALL produce output values that match, within a relative tolerance of 1e-10, the values obtained by invoking the HS100 evaluator directly with the same default input values.
+2. WHEN the Component wraps any TestEvaluator from `standard_evaluator.evaluators.test`, THE Component SHALL complete `problem.setup()` and `problem.run_model()` without raising an exception.
+3. WHEN the Component wraps any TestEvaluator from `standard_evaluator.evaluators.test` and `problem.run_model()` completes, THE Component SHALL produce output values for each response that match, within a relative tolerance of 1e-10, the values obtained by invoking the same evaluator directly with default input values.

--- a/.kiro/specs/openmdao-component-migration/tasks.md
+++ b/.kiro/specs/openmdao-component-migration/tasks.md
@@ -1,0 +1,114 @@
+# Implementation Plan: OpenMDAO Component Migration
+
+## Overview
+
+Migrate `EvaluatorOpenMdaoComponent` from boeing-standard-evaluator into the standard-evaluator library. The component wraps any `Evaluator` as an OpenMDAO `ExplicitComponent`, adapting from the legacy dict-based `problem` API to the pydantic `OptProblem` API. Implementation uses Python and targets the `standard_evaluator.components` subpackage.
+
+## Tasks
+
+- [x] 1. Create components subpackage and implement EvaluatorOpenMdaoComponent
+  - [x] 1.1 Create the `standard_evaluator/components/` package with `__init__.py`
+    - Create `src/standard_evaluator/components/__init__.py`
+    - Export `EvaluatorOpenMdaoComponent` in `__all__`
+    - _Requirements: 1.1, 1.2, 1.3_
+
+  - [x] 1.2 Implement the `EvaluatorOpenMdaoComponent` class in `evaluator_om_component.py`
+    - Create `src/standard_evaluator/components/evaluator_om_component.py`
+    - Implement `__init__` with deep copy of evaluator, type checking, kwarg conflict detection, and fallback via `SurrogateModel.from_dict()`
+    - Implement `initialize` to declare `evaluator_options` option when evaluator has `to_dict()`
+    - Implement `setup` to map `opt_problem.variables` to OpenMDAO inputs and `opt_problem.responses` to OpenMDAO outputs with bounds, scaling, and defaults
+    - Implement `compute` to build DataFrame from inputs, call evaluator, and extract responses to outputs
+    - Handle all error cases: TypeError for non-Evaluator, AttributeError for missing evaluator/options, ValueError for discrete inputs/outputs, ValueError for scale=0.0
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3, 5.4, 5.5, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6_
+
+- [x] 2. Checkpoint - Verify component module structure
+  - Ensure the package imports resolve correctly, ask the user if questions arise.
+
+- [x] 3. Write unit and integration tests
+  - [x] 3.1 Create test directory structure and unit tests
+    - Create `tests/components/__init__.py`
+    - Create `tests/components/test_evaluator_om_component.py`
+    - Test import resolution (`from standard_evaluator.components import EvaluatorOpenMdaoComponent`)
+    - Test TypeError when non-Evaluator is passed as first arg
+    - Test AttributeError when no evaluator and no evaluator_options provided
+    - Test kwarg conflict detection raises clear error
+    - Test ValueError for discrete_inputs not None
+    - Test ValueError for discrete_outputs not None
+    - Test ValueError for response with scale=0.0
+    - Test exception propagation from SurrogateModel.from_dict with invalid options
+    - Test exception propagation from evaluator during compute
+    - _Requirements: 1.1, 1.2, 1.3, 2.2, 2.4, 3.2, 3.3, 6.6, 7.4, 7.5, 7.6_
+
+  - [x] 3.2 Write integration tests with TestEvaluators
+    - Test end-to-end with HS100 evaluator: setup, run_model, verify outputs match direct evaluator call within 1e-10 tolerance
+    - Test SurrogateModel.from_dict reconstruction path
+    - Test with multiple TestEvaluators from `standard_evaluator.evaluators.test`
+    - _Requirements: 3.1, 8.1, 8.2, 8.3_
+
+- [x] 4. Checkpoint - Ensure all unit and integration tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Write property-based tests
+  - [x] 5.1 Write property test for deep copy isolation
+    - **Property 1: Deep Copy Isolation**
+    - Construct component with evaluator, mutate original evaluator's opt_problem, verify component's stored evaluator is unaffected
+    - **Validates: Requirements 2.1**
+
+  - [x] 5.2 Write property test for serialization option round trip
+    - **Property 2: Serialization Option Round Trip**
+    - Use SurrogateModel instances with to_dict, verify options["evaluator_options"] equals to_dict() result
+    - **Validates: Requirements 4.2**
+
+  - [x] 5.3 Write property test for variable-to-input default mapping
+    - **Property 3: Variable-to-Input Default Mapping**
+    - Generate FloatVariables with various defaults/bounds combinations, verify correct input default values
+    - **Validates: Requirements 5.2, 5.3, 5.4, 5.5**
+
+  - [x] 5.4 Write property test for response-to-output bounds mapping
+    - **Property 4: Response-to-Output Bounds Mapping**
+    - Generate response Variables with mix of finite/infinite bounds, verify OpenMDAO output bounds are correct
+    - **Validates: Requirements 6.3, 6.4**
+
+  - [x] 5.5 Write property test for response scaling formula
+    - **Property 5: Response Scaling Formula**
+    - Generate response Variables with arbitrary shift/scale (scale != 0), verify ref0 = -shift and ref = (1.0/scale) + ref0
+    - **Validates: Requirements 6.5**
+
+  - [x] 5.6 Write property test for compute round trip
+    - **Property 6: Compute Round Trip**
+    - Parametrize over TestEvaluators, verify component outputs match direct evaluator call within 1e-10 tolerance
+    - **Validates: Requirements 7.1, 7.2, 7.3, 8.2, 8.3**
+
+- [x] 6. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- **CRITICAL: All task execution MUST follow the workspace steering files** defined in `.kiro/steering/`, especially `.kiro/steering/python-environment.md`. This means:
+  - NEVER use `python`, `python3`, `py`, or any system Python directly
+  - ALWAYS use `.venv\Scripts\python.exe` for all Python commands
+  - For pytest: `.venv\Scripts\python.exe -m pytest`
+  - For pip installs: `.venv\Scripts\python.exe -m pip install ...`
+  - Working directory: `c:\dev\standard-evaluator`
+- Also follow `.kiro/steering/git-rules.md` for any git operations
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The implementation uses the pydantic `OptProblem` API (`opt_problem.variables`, `opt_problem.responses`) instead of the legacy dict-based `problem` API
+- Test file for property-based tests: `tests/components/test_pbt_evaluator_om_component.py`
+- Hypothesis is already available as a test dependency in pyproject.toml
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2"] },
+    { "id": 2, "tasks": ["3.1", "3.2"] },
+    { "id": 3, "tasks": ["5.1", "5.2", "5.3", "5.4", "5.5", "5.6"] }
+  ]
+}
+```

--- a/src/standard_evaluator/components/__init__.py
+++ b/src/standard_evaluator/components/__init__.py
@@ -1,0 +1,7 @@
+"""OpenMDAO component wrappers for standard evaluators."""
+
+from standard_evaluator.components.evaluator_om_component import (
+    EvaluatorOpenMdaoComponent,
+)
+
+__all__ = ["EvaluatorOpenMdaoComponent"]

--- a/src/standard_evaluator/components/evaluator_om_component.py
+++ b/src/standard_evaluator/components/evaluator_om_component.py
@@ -1,0 +1,171 @@
+"""Module defining a class that exposes any Standard evaluator as an OpenMDAO component."""
+
+import copy
+
+import numpy as np
+import pandas as pd
+import openmdao.api as om
+
+from standard_evaluator.evaluators.abstract_evaluator import Evaluator
+from standard_evaluator.surrogate_models.abstract_model import SurrogateModel
+
+EVALUATOR_OPTION_NAME = "evaluator_options"
+
+
+class EvaluatorOpenMdaoComponent(om.ExplicitComponent):
+    """Exposes a Standard Evaluator as an OpenMDAO ExplicitComponent.
+
+    This component wraps a Standard Evaluator so it can be used within an
+    OpenMDAO model. It maps evaluator variables to component inputs and
+    evaluator responses to component outputs.
+    """
+
+    def __init__(self, evaluator: Evaluator = None, **kwargs: dict):
+        """Initialize the component and store the evaluator.
+
+        Args:
+            evaluator: The Standard evaluator that will be wrapped. If None,
+                the evaluator is created from the evaluator_options in kwargs.
+            **kwargs: Keyword arguments passed to the OpenMDAO ExplicitComponent
+                constructor.
+
+        Raises:
+            TypeError: If evaluator is provided but is not an instance of Evaluator.
+            AttributeError: If no evaluator is provided and no evaluator_options
+                key exists in kwargs.
+        """
+        if evaluator is not None:
+            # Type check: must be an instance of Evaluator
+            if not isinstance(evaluator, Evaluator):
+                raise TypeError(
+                    f"The evaluator argument must be an instance of Evaluator. "
+                    f"Received a {type(evaluator).__name__} instead."
+                )
+        else:
+            # Fallback: reconstruct from evaluator_options
+            if EVALUATOR_OPTION_NAME in kwargs:
+                evaluator = SurrogateModel.from_dict(kwargs.pop(EVALUATOR_OPTION_NAME))
+            else:
+                raise AttributeError(
+                    f"No evaluator and no {EVALUATOR_OPTION_NAME} defined."
+                )
+
+        # Detect kwarg conflicts with internal attributes
+        conflicting_keys = [key for key in kwargs if hasattr(self, key) or key == "eval"]
+        if conflicting_keys:
+            raise ValueError(
+                f"Keyword argument(s) {conflicting_keys} conflict with internal "
+                f"Component attribute(s). Please rename them."
+            )
+
+        # Store a deep copy of the evaluator
+        self.eval = copy.deepcopy(evaluator)
+        super().__init__(**kwargs)
+
+    def initialize(self):
+        """Declare component options.
+
+        Stores the evaluator information in the evaluator_options option
+        if the evaluator has a ``to_dict`` method.
+        """
+        if hasattr(self.eval, "to_dict"):
+            self.options.declare(
+                EVALUATOR_OPTION_NAME,
+                types=dict,
+                desc="Surrogate model information",
+            )
+            self.options[EVALUATOR_OPTION_NAME] = self.eval.to_dict()
+
+    def setup(self):
+        """Set up component inputs and outputs from the evaluator's OptProblem.
+
+        Maps opt_problem.variables to OpenMDAO inputs and opt_problem.responses
+        to OpenMDAO outputs with bounds, scaling, and defaults.
+
+        Raises:
+            ValueError: If a response has a scale value of 0.0.
+        """
+        opt_problem = self.eval.opt_problem
+
+        # Set all inputs from variables
+        for var in opt_problem.variables:
+            # Determine default value
+            if var.default is not None:
+                default_value = var.default
+            else:
+                # Calculate midpoint from bounds
+                lower, upper = var.bounds
+                default_value = (lower + upper) / 2.0
+
+            self.add_input(var.name, val=default_value)
+
+        # Set all outputs from responses
+        for resp in opt_problem.responses:
+            # Determine bounds
+            lower, upper = resp.bounds[0], resp.bounds[1]
+
+            # Convert infinite bounds to None for OpenMDAO
+            if not np.isfinite(lower):
+                lower = None
+            if not np.isfinite(upper):
+                upper = None
+
+            # Calculate ref0 and ref from shift and scale
+            shift = resp.shift if resp.shift is not None else 0.0
+            scale = resp.scale if resp.scale is not None else 1.0
+
+            if scale == 0.0:
+                raise ValueError(
+                    f"Response {resp.name} has a scale value of 0.0"
+                )
+
+            ref0 = -shift
+            ref = (1.0 / scale) + ref0
+
+            self.add_output(
+                resp.name,
+                lower=lower,
+                upper=upper,
+                ref0=ref0,
+                ref=ref,
+                val=0.0,
+            )
+
+    def compute(
+        self,
+        inputs: dict,
+        outputs: dict,
+        discrete_inputs: dict = None,
+        discrete_outputs: dict = None,
+    ):
+        """Compute responses using the Standard evaluator.
+
+        Builds a DataFrame from OpenMDAO inputs, calls the evaluator, and
+        extracts responses back to OpenMDAO outputs.
+
+        Args:
+            inputs: Unscaled, dimensional input variables read via inputs[key].
+            outputs: Unscaled, dimensional output variables read via outputs[key].
+            discrete_inputs: If not None, dict containing discrete input values.
+            discrete_outputs: If not None, dict containing discrete output values.
+
+        Raises:
+            ValueError: If discrete_inputs or discrete_outputs are provided.
+        """
+        if discrete_inputs is not None:
+            raise ValueError("At this point we do not yet support discrete inputs")
+        if discrete_outputs is not None:
+            raise ValueError("At this point we do not yet support discrete outputs")
+
+        # Build input dictionary from OpenMDAO inputs
+        input_dict = {}
+        for var in self.eval.inputs:
+            input_dict[var] = inputs[var]
+
+        # Create the DataFrame and evaluate
+        data_frame = pd.DataFrame(data=input_dict)
+        self.eval(data_frame)
+
+        # Extract responses to outputs
+        for response in self.eval.outputs:
+            outputs[response] = data_frame[response].iloc[0]

--- a/tests/components/__init__.py
+++ b/tests/components/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the standard_evaluator.components subpackage."""

--- a/tests/components/test_evaluator_om_component.py
+++ b/tests/components/test_evaluator_om_component.py
@@ -1,0 +1,300 @@
+"""Unit tests for EvaluatorOpenMdaoComponent.
+
+Tests cover import resolution, constructor error handling, kwarg conflict
+detection, discrete input/output rejection, response scaling validation,
+and exception propagation.
+
+Requirements: 1.1, 1.2, 1.3, 2.2, 2.4, 3.2, 3.3, 6.6, 7.4, 7.5, 7.6
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import openmdao.api as om
+
+from standard_evaluator.components import EvaluatorOpenMdaoComponent
+from standard_evaluator.components.evaluator_om_component import (
+    EvaluatorOpenMdaoComponent as DirectImport,
+)
+from standard_evaluator.evaluators.abstract_evaluator import Evaluator
+from standard_evaluator.surrogate_models.abstract_model import SurrogateModel
+from standard_evaluator.problem import OptProblem, FloatVariable
+from standard_evaluator.evaluators.test import HS100
+import standard_evaluator as se
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class SimpleEvaluator(Evaluator):
+    """Minimal evaluator for unit tests."""
+
+    def _evaluate(self, sites: pd.DataFrame) -> None:
+        sites["f"] = sites["x1"] + sites["x2"]
+
+
+class FailingEvaluator(Evaluator):
+    """Evaluator that always raises during evaluation."""
+
+    def _evaluate(self, sites: pd.DataFrame) -> None:
+        raise RuntimeError("Intentional failure during evaluation")
+
+
+def _make_simple_evaluator() -> SimpleEvaluator:
+    """Create a simple evaluator with 2 variables and 1 response."""
+    opt_problem = se.utilities.create_opt_problem(num_independent=2, num_dependent=1)
+    opt_problem.variables[0].name = "x1"
+    opt_problem.variables[0].bounds = [-5.0, 5.0]
+    opt_problem.variables[0].default = 1.0
+    opt_problem.variables[1].name = "x2"
+    opt_problem.variables[1].bounds = [-5.0, 5.0]
+    opt_problem.variables[1].default = 2.0
+    opt_problem.responses[0].name = "f"
+    opt_problem.responses[0].bounds = (-np.inf, np.inf)
+    opt_problem.objectives = ["f"]
+    opt_problem.constraints = []
+    return SimpleEvaluator(opt_problem=opt_problem)
+
+
+def _make_evaluator_with_zero_scale() -> SimpleEvaluator:
+    """Create an evaluator where a response has scale=0.0.
+
+    Uses model_construct to bypass pydantic validation so we can test
+    the component's own scale=0.0 guard in setup().
+    """
+    opt_problem = se.utilities.create_opt_problem(num_independent=2, num_dependent=1)
+    opt_problem.variables[0].name = "x1"
+    opt_problem.variables[0].bounds = [-5.0, 5.0]
+    opt_problem.variables[0].default = 1.0
+    opt_problem.variables[1].name = "x2"
+    opt_problem.variables[1].bounds = [-5.0, 5.0]
+    opt_problem.variables[1].default = 2.0
+    # Bypass pydantic validation to inject scale=0.0
+    bad_response = FloatVariable.model_construct(
+        name="f",
+        bounds=(-np.inf, np.inf),
+        shift=0.0,
+        scale=0.0,
+        default=None,
+        units=None,
+        description="",
+        options={},
+        class_type="float",
+    )
+    opt_problem.responses[0] = bad_response
+    opt_problem.objectives = ["f"]
+    opt_problem.constraints = []
+    return SimpleEvaluator(opt_problem=opt_problem)
+
+
+def _make_failing_evaluator() -> FailingEvaluator:
+    """Create an evaluator that raises during compute."""
+    opt_problem = se.utilities.create_opt_problem(num_independent=2, num_dependent=1)
+    opt_problem.variables[0].name = "x1"
+    opt_problem.variables[0].bounds = [-5.0, 5.0]
+    opt_problem.variables[0].default = 1.0
+    opt_problem.variables[1].name = "x2"
+    opt_problem.variables[1].bounds = [-5.0, 5.0]
+    opt_problem.variables[1].default = 2.0
+    opt_problem.responses[0].name = "f"
+    opt_problem.responses[0].bounds = (-np.inf, np.inf)
+    opt_problem.objectives = ["f"]
+    opt_problem.constraints = []
+    return FailingEvaluator(opt_problem=opt_problem)
+
+
+# ---------------------------------------------------------------------------
+# Requirement 1.1, 1.2, 1.3 — Import resolution
+# ---------------------------------------------------------------------------
+
+
+class TestImportResolution:
+    """Verify that the component can be imported from the expected locations."""
+
+    def test_import_from_components_package(self):
+        """from standard_evaluator.components import EvaluatorOpenMdaoComponent"""
+        assert EvaluatorOpenMdaoComponent is not None
+
+    def test_import_from_module_directly(self):
+        """from standard_evaluator.components.evaluator_om_component import ..."""
+        assert DirectImport is not None
+        assert DirectImport is EvaluatorOpenMdaoComponent
+
+    def test_in_all_list(self):
+        """EvaluatorOpenMdaoComponent is in __all__."""
+        import standard_evaluator.components as comp_pkg
+
+        assert "EvaluatorOpenMdaoComponent" in comp_pkg.__all__
+
+
+# ---------------------------------------------------------------------------
+# Requirement 2.4 — TypeError when non-Evaluator is passed
+# ---------------------------------------------------------------------------
+
+
+class TestTypeErrorForNonEvaluator:
+    """Constructor raises TypeError if the first arg is not an Evaluator."""
+
+    def test_raises_on_string(self):
+        with pytest.raises(TypeError, match="Evaluator"):
+            EvaluatorOpenMdaoComponent("not an evaluator")
+
+    def test_raises_on_integer(self):
+        with pytest.raises(TypeError, match="Evaluator"):
+            EvaluatorOpenMdaoComponent(42)
+
+    def test_raises_on_dict(self):
+        with pytest.raises(TypeError, match="Evaluator"):
+            EvaluatorOpenMdaoComponent({"key": "value"})
+
+    def test_raises_on_none_like_object(self):
+        """An object that is not None but also not an Evaluator."""
+
+        class FakeEvaluator:
+            pass
+
+        with pytest.raises(TypeError, match="Evaluator"):
+            EvaluatorOpenMdaoComponent(FakeEvaluator())
+
+
+# ---------------------------------------------------------------------------
+# Requirement 3.2 — AttributeError when no evaluator and no evaluator_options
+# ---------------------------------------------------------------------------
+
+
+class TestAttributeErrorNoEvaluatorOptions:
+    """Constructor raises AttributeError when neither evaluator nor options given."""
+
+    def test_raises_attribute_error(self):
+        with pytest.raises(AttributeError, match="evaluator_options"):
+            EvaluatorOpenMdaoComponent()
+
+    def test_raises_with_irrelevant_kwargs(self):
+        """Other kwargs present but not evaluator_options."""
+        with pytest.raises(AttributeError, match="evaluator_options"):
+            EvaluatorOpenMdaoComponent(evaluator=None, some_other_key="value")
+
+
+# ---------------------------------------------------------------------------
+# Requirement 2.2 — Kwarg conflict detection
+# ---------------------------------------------------------------------------
+
+
+class TestKwargConflictDetection:
+    """Constructor raises a clear error on conflicting kwargs."""
+
+    def test_raises_on_eval_kwarg(self):
+        """'eval' conflicts with the stored evaluator attribute."""
+        evaluator = _make_simple_evaluator()
+        with pytest.raises(ValueError, match="eval"):
+            EvaluatorOpenMdaoComponent(evaluator, eval="conflict")
+
+
+# ---------------------------------------------------------------------------
+# Requirement 7.4 — ValueError for discrete_inputs not None
+# ---------------------------------------------------------------------------
+
+
+class TestDiscreteInputsRejected:
+    """compute() raises ValueError if discrete_inputs is not None."""
+
+    def test_raises_value_error(self):
+        evaluator = _make_simple_evaluator()
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        comp = prob.model.comp
+        # Call compute directly with discrete_inputs
+        inputs = {"x1": np.array([1.0]), "x2": np.array([2.0])}
+        outputs = {"f": np.array([0.0])}
+        with pytest.raises(ValueError, match="discrete inputs"):
+            comp.compute(inputs, outputs, discrete_inputs={"d": 1})
+
+
+# ---------------------------------------------------------------------------
+# Requirement 7.5 — ValueError for discrete_outputs not None
+# ---------------------------------------------------------------------------
+
+
+class TestDiscreteOutputsRejected:
+    """compute() raises ValueError if discrete_outputs is not None."""
+
+    def test_raises_value_error(self):
+        evaluator = _make_simple_evaluator()
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        comp = prob.model.comp
+        inputs = {"x1": np.array([1.0]), "x2": np.array([2.0])}
+        outputs = {"f": np.array([0.0])}
+        with pytest.raises(ValueError, match="discrete outputs"):
+            comp.compute(inputs, outputs, discrete_outputs={"d": 1})
+
+
+# ---------------------------------------------------------------------------
+# Requirement 6.6 — ValueError for response with scale=0.0
+# ---------------------------------------------------------------------------
+
+
+class TestScaleZeroRaisesValueError:
+    """setup() raises ValueError when a response has scale=0.0."""
+
+    def test_raises_value_error(self):
+        evaluator = _make_evaluator_with_zero_scale()
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        with pytest.raises(ValueError, match="scale value of 0.0"):
+            prob.setup()
+
+
+# ---------------------------------------------------------------------------
+# Requirement 3.3 — Exception propagation from SurrogateModel.from_dict
+# ---------------------------------------------------------------------------
+
+
+class TestFromDictExceptionPropagation:
+    """Exceptions from SurrogateModel.from_dict propagate to the caller."""
+
+    def test_type_error_on_non_dict_options(self):
+        """Passing a non-dict as evaluator_options triggers from_dict TypeError."""
+        with pytest.raises(TypeError):
+            EvaluatorOpenMdaoComponent(evaluator_options="not a dict")
+
+    def test_key_error_on_missing_keys(self):
+        """A dict missing required keys raises KeyError from from_dict."""
+        with pytest.raises((KeyError, TypeError)):
+            EvaluatorOpenMdaoComponent(evaluator_options={"incomplete": True})
+
+
+# ---------------------------------------------------------------------------
+# Requirement 7.6 — Exception propagation from evaluator during compute
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatorExceptionPropagation:
+    """Exceptions raised by the evaluator during compute propagate unchanged."""
+
+    def test_runtime_error_propagates(self):
+        evaluator = _make_failing_evaluator()
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        comp = prob.model.comp
+        inputs = {"x1": np.array([1.0]), "x2": np.array([2.0])}
+        outputs = {"f": np.array([0.0])}
+        with pytest.raises(RuntimeError, match="Intentional failure"):
+            comp.compute(inputs, outputs)

--- a/tests/components/test_evaluator_om_component.py
+++ b/tests/components/test_evaluator_om_component.py
@@ -18,8 +18,7 @@ from standard_evaluator.components.evaluator_om_component import (
     EvaluatorOpenMdaoComponent as DirectImport,
 )
 from standard_evaluator.evaluators.abstract_evaluator import Evaluator
-from standard_evaluator.surrogate_models.abstract_model import SurrogateModel
-from standard_evaluator.problem import OptProblem, FloatVariable
+from standard_evaluator.problem import FloatVariable
 from standard_evaluator.evaluators.test import HS100
 import standard_evaluator as se
 
@@ -125,9 +124,7 @@ class TestImportResolution:
 
     def test_in_all_list(self):
         """EvaluatorOpenMdaoComponent is in __all__."""
-        import standard_evaluator.components as comp_pkg
-
-        assert "EvaluatorOpenMdaoComponent" in comp_pkg.__all__
+        assert EvaluatorOpenMdaoComponent.__name__ in se.components.__all__
 
 
 # ---------------------------------------------------------------------------

--- a/tests/components/test_pbt_evaluator_om_component.py
+++ b/tests/components/test_pbt_evaluator_om_component.py
@@ -1,0 +1,716 @@
+"""Property-based tests for EvaluatorOpenMdaoComponent.
+
+Uses Hypothesis to validate correctness properties of the OpenMDAO component
+wrapper across a range of inputs and evaluator configurations.
+
+# Feature: openmdao-component-migration
+"""
+
+import copy
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import openmdao.api as om
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+import standard_evaluator as se
+from standard_evaluator.components import EvaluatorOpenMdaoComponent
+from standard_evaluator.evaluators.abstract_evaluator import Evaluator
+from standard_evaluator.evaluators.test import (
+    HS100,
+    Rosenbrock,
+    Sphere,
+    ConstrainedBetts,
+)
+from standard_evaluator.problem import OptProblem, FloatVariable
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class SimpleEvaluator(Evaluator):
+    """Minimal evaluator for property-based tests."""
+
+    __test__ = False
+
+    def _evaluate(self, sites: pd.DataFrame) -> None:
+        for resp in self.outputs:
+            sites[resp] = sites[self.inputs[0]]
+
+
+def _create_evaluator_instance(evaluator_cls):
+    """Create a TestEvaluator instance, handling classes that require kwargs."""
+    if evaluator_cls in (Rosenbrock, Sphere):
+        return evaluator_cls(num_independent=2, num_dependent=1)
+    return evaluator_cls()
+
+
+def _get_variable_bounds(evaluator):
+    """Extract variable bounds as a list of (lower, upper) tuples."""
+    bounds = []
+    for var in evaluator.opt_problem.variables:
+        lower, upper = var.bounds
+        bounds.append((float(lower), float(upper)))
+    return bounds
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Strategy for finite float bounds where lower < upper
+_finite_bounds_strategy = st.tuples(
+    st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+    st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+).map(lambda t: (min(t), max(t))).filter(lambda t: t[0] < t[1])
+
+# Strategy for optional defaults
+_default_strategy = st.one_of(
+    st.none(),
+    st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+)
+
+# Strategy for mutations to apply to opt_problem after component construction
+_mutation_strategy = st.sampled_from([
+    "rename_variable",
+    "change_bounds",
+    "change_default",
+    "add_variable",
+    "change_response_name",
+])
+
+
+@st.composite
+def evaluator_with_varied_opt_problem(draw):
+    """Generate a SimpleEvaluator with a randomized opt_problem structure.
+
+    Generates 1-3 variables and 1-2 responses with varied bounds and defaults.
+    """
+    num_vars = draw(st.integers(min_value=1, max_value=3))
+    num_resp = draw(st.integers(min_value=1, max_value=2))
+
+    # Build variables with random bounds and defaults
+    variables = []
+    for i in range(num_vars):
+        bounds = draw(_finite_bounds_strategy)
+        default = draw(_default_strategy)
+        # Clamp default within bounds if provided
+        if default is not None:
+            default = max(bounds[0], min(bounds[1], default))
+        variables.append(
+            FloatVariable(name=f"x{i}", bounds=bounds, default=default)
+        )
+
+    # Build responses
+    responses = []
+    for i in range(num_resp):
+        responses.append(FloatVariable(name=f"f{i}"))
+
+    opt_problem = OptProblem(
+        variables=variables,
+        responses=responses,
+        objectives=[responses[0].name],
+    )
+
+    return SimpleEvaluator(opt_problem=opt_problem)
+
+
+# ---------------------------------------------------------------------------
+# Property 1: Deep Copy Isolation
+# Feature: openmdao-component-migration, Property 1: Deep Copy Isolation
+# ---------------------------------------------------------------------------
+
+
+def _apply_mutation(evaluator: Evaluator, mutation: str) -> None:
+    """Apply a mutation to the evaluator's opt_problem to test isolation."""
+    opt = evaluator.opt_problem
+
+    if mutation == "rename_variable":
+        opt.variables[0].name = "mutated_var_name"
+    elif mutation == "change_bounds":
+        opt.variables[0].bounds = (-999.0, 999.0)
+    elif mutation == "change_default":
+        opt.variables[0].default = 42.42
+    elif mutation == "add_variable":
+        new_var = FloatVariable(name="new_injected_var", bounds=(-1.0, 1.0))
+        opt.variables.append(new_var)
+    elif mutation == "change_response_name":
+        opt.responses[0].name = "mutated_resp_name"
+
+
+class TestDeepCopyIsolation:
+    """Property 1: Deep Copy Isolation.
+
+    For any Evaluator instance used to construct the component, mutating the
+    original Evaluator's opt_problem after construction SHALL NOT affect the
+    component's stored evaluator.
+
+    **Validates: Requirements 2.1**
+    """
+
+    @given(
+        evaluator=evaluator_with_varied_opt_problem(),
+        mutation=_mutation_strategy,
+    )
+    @settings(max_examples=100, deadline=None)
+    def test_deep_copy_isolation(self, evaluator, mutation):
+        """Mutating the original evaluator does not affect the component."""
+        # Snapshot the component's evaluator state after construction
+        component = EvaluatorOpenMdaoComponent(evaluator)
+        component_vars_snapshot = [
+            v.model_dump() for v in component.eval.opt_problem.variables
+        ]
+        component_resps_snapshot = [
+            r.model_dump() for r in component.eval.opt_problem.responses
+        ]
+
+        # Mutate the original evaluator's opt_problem
+        _apply_mutation(evaluator, mutation)
+
+        # Verify the component's stored evaluator is completely unaffected
+        component_vars_after = [
+            v.model_dump() for v in component.eval.opt_problem.variables
+        ]
+        component_resps_after = [
+            r.model_dump() for r in component.eval.opt_problem.responses
+        ]
+
+        assert component_vars_snapshot == component_vars_after, (
+            f"Component variables were affected by mutation '{mutation}' "
+            f"on original evaluator"
+        )
+        assert component_resps_snapshot == component_resps_after, (
+            f"Component responses were affected by mutation '{mutation}' "
+            f"on original evaluator"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property 5: Response Scaling Formula
+# Feature: openmdao-component-migration, Property 5: Response Scaling Formula
+# ---------------------------------------------------------------------------
+
+
+class TestResponseScalingFormula:
+    """Property 5: Response Scaling Formula.
+
+    For any response Variable with shift and scale values (where scale != 0),
+    the OpenMDAO output ref0 SHALL equal -shift and ref SHALL equal
+    (1.0 / scale) + ref0.
+
+    **Validates: Requirements 6.5**
+    """
+
+    @given(
+        shift=st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+        scale=st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+    )
+    @settings(max_examples=100, deadline=None)
+    def test_scaling_formula(self, shift: float, scale: float):
+        """ref0 = -shift and ref = (1.0/scale) + ref0 for any non-zero scale."""
+        # scale must not be zero
+        assume(abs(scale) > 1e-15)
+
+        # Build a response variable with the given shift and scale
+        # Use model_construct to bypass pydantic validation for arbitrary values
+        response = FloatVariable.model_construct(
+            name="f",
+            bounds=(-np.inf, np.inf),
+            shift=shift,
+            scale=scale,
+            default=None,
+            units=None,
+            description="",
+            options={},
+            class_type="float",
+        )
+
+        opt_problem = OptProblem(
+            variables=[FloatVariable(name="x1", bounds=(0.0, 10.0), default=5.0)],
+            responses=[response],
+        )
+        evaluator = SimpleEvaluator(opt_problem=opt_problem)
+
+        # Set up the OpenMDAO problem
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        # Access output metadata to verify ref0 and ref
+        meta = prob.model.comp.get_io_metadata(iotypes="output")
+        output_meta = meta["f"]
+
+        # Expected values per the formula
+        expected_ref0 = -shift
+        expected_ref = (1.0 / scale) + expected_ref0
+
+        # Verify the scaling formula
+        assert output_meta["ref0"] == pytest.approx(expected_ref0, rel=1e-12, abs=1e-15), (
+            f"ref0 mismatch: got {output_meta['ref0']}, expected {expected_ref0} "
+            f"(shift={shift})"
+        )
+        assert output_meta["ref"] == pytest.approx(expected_ref, rel=1e-12, abs=1e-15), (
+            f"ref mismatch: got {output_meta['ref']}, expected {expected_ref} "
+            f"(shift={shift}, scale={scale})"
+        )
+
+# ---------------------------------------------------------------------------
+# Strategies for Property 3
+# ---------------------------------------------------------------------------
+
+# Strategy for variable names (valid identifiers, no whitespace)
+_var_names = st.from_regex(r"[a-z][a-z0-9_]{0,9}", fullmatch=True)
+
+
+@st.composite
+def float_variable_with_explicit_default(draw):
+    """Generate a FloatVariable with an explicit default value (not None).
+
+    The default may fall inside or outside the bounds.
+    """
+    name = draw(_var_names)
+    lower = draw(
+        st.floats(min_value=-1e6, max_value=1e6 - 1,
+                  allow_nan=False, allow_infinity=False)
+    )
+    upper = draw(
+        st.floats(min_value=lower + 0.01, max_value=1e6,
+                  allow_nan=False, allow_infinity=False)
+    )
+    assume(upper > lower)
+    default_val = draw(
+        st.floats(min_value=-1e8, max_value=1e8,
+                  allow_nan=False, allow_infinity=False)
+    )
+    return FloatVariable(name=name, bounds=(lower, upper), default=default_val)
+
+
+@st.composite
+def float_variable_without_explicit_default(draw):
+    """Generate a FloatVariable with default=None (use midpoint of bounds)."""
+    name = draw(_var_names)
+    lower = draw(
+        st.floats(min_value=-1e6, max_value=1e6 - 1,
+                  allow_nan=False, allow_infinity=False)
+    )
+    upper = draw(
+        st.floats(min_value=lower + 0.01, max_value=1e6,
+                  allow_nan=False, allow_infinity=False)
+    )
+    assume(upper > lower)
+    return FloatVariable(name=name, bounds=(lower, upper), default=None)
+
+
+# ---------------------------------------------------------------------------
+# Property 3: Variable-to-Input Default Mapping
+# Feature: openmdao-component-migration, Property 3: Variable-to-Input Default Mapping
+# ---------------------------------------------------------------------------
+
+
+class DummyDefaultEvaluator(Evaluator):
+    """Minimal evaluator that returns zeros for all responses."""
+
+    __test__ = False
+
+    def _evaluate(self, sites: pd.DataFrame) -> None:
+        for resp in self.outputs:
+            sites[resp] = 0.0
+
+
+class TestVariableToInputDefaultMapping:
+    """Property 3: Variable-to-Input Default Mapping.
+
+    For any Variable in the evaluator's opt_problem.variables, the
+    corresponding OpenMDAO input default value SHALL be variable.default if
+    variable.default is not None, otherwise it SHALL be the midpoint of
+    the variable's bounds (lower + upper) / 2.
+
+    **Validates: Requirements 5.2, 5.3, 5.4, 5.5**
+    """
+
+    @given(var=float_variable_with_explicit_default())
+    @settings(max_examples=100, deadline=None)
+    def test_explicit_default_used_as_input_value(self, var: FloatVariable):
+        """When var.default is not None, the input default equals var.default.
+
+        **Validates: Requirements 5.2, 5.3, 5.5**
+        """
+        # Build evaluator with a single variable and a single response
+        opt_problem = OptProblem(
+            variables=[var],
+            responses=[
+                FloatVariable(name="resp_out", bounds=(-np.inf, np.inf))
+            ],
+        )
+        evaluator = DummyDefaultEvaluator(opt_problem=opt_problem)
+
+        # Create OpenMDAO problem and setup
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        # Verify the input default matches var.default
+        actual_default = prob.get_val(var.name).flatten()[0]
+        expected_default = var.default
+        assert np.isclose(actual_default, expected_default, rtol=1e-10), (
+            f"Expected input default={expected_default} for variable "
+            f"'{var.name}' with explicit default, got {actual_default}"
+        )
+
+    @given(var=float_variable_without_explicit_default())
+    @settings(max_examples=100, deadline=None)
+    def test_midpoint_default_when_no_explicit_default(
+        self, var: FloatVariable
+    ):
+        """When var.default is None, the input default equals (lower+upper)/2.
+
+        **Validates: Requirements 5.2, 5.4**
+        """
+        # Build evaluator with a single variable and a single response
+        opt_problem = OptProblem(
+            variables=[var],
+            responses=[
+                FloatVariable(name="resp_out", bounds=(-np.inf, np.inf))
+            ],
+        )
+        evaluator = DummyDefaultEvaluator(opt_problem=opt_problem)
+
+        # Create OpenMDAO problem and setup
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        # Verify the input default is the midpoint of bounds
+        lower, upper = var.bounds
+        expected_default = (lower + upper) / 2.0
+        actual_default = prob.get_val(var.name).flatten()[0]
+        assert np.isclose(actual_default, expected_default, rtol=1e-10), (
+            f"Expected input default={expected_default} (midpoint of "
+            f"[{lower}, {upper}]) for variable '{var.name}' with no "
+            f"explicit default, got {actual_default}"
+        )
+
+    @given(var=float_variable_with_explicit_default())
+    @settings(max_examples=100, deadline=None)
+    def test_explicit_default_ignores_bounds_for_calculation(
+        self, var: FloatVariable
+    ):
+        """When both default and bounds exist, the explicit default is used
+        regardless of whether it falls inside or outside the bounds.
+
+        **Validates: Requirements 5.3, 5.5**
+        """
+        # Build evaluator with a single variable and a single response
+        opt_problem = OptProblem(
+            variables=[var],
+            responses=[
+                FloatVariable(name="resp_out", bounds=(-np.inf, np.inf))
+            ],
+        )
+        evaluator = DummyDefaultEvaluator(opt_problem=opt_problem)
+
+        # Create OpenMDAO problem and setup
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        # The input default should be var.default, NOT the midpoint
+        actual_default = prob.get_val(var.name).flatten()[0]
+        lower, upper = var.bounds
+        midpoint = (lower + upper) / 2.0
+
+        # It should equal the explicit default
+        assert np.isclose(actual_default, var.default, rtol=1e-10)
+
+        # Verify it's not accidentally the midpoint
+        # (unless they happen to be equal)
+        if not np.isclose(var.default, midpoint, rtol=1e-10):
+            assert not np.isclose(actual_default, midpoint, rtol=1e-10), (
+                f"Input default should be the explicit default "
+                f"{var.default}, not the midpoint {midpoint}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Property 6: Compute Round Trip
+# Feature: openmdao-component-migration, Property 6: Compute Round Trip
+# ---------------------------------------------------------------------------
+
+
+def input_values_strategy(evaluator):
+    """Create a strategy that generates input values within variable bounds."""
+    var_bounds = _get_variable_bounds(evaluator)
+    strategies = []
+    for lower, upper in var_bounds:
+        strategies.append(
+            st.floats(
+                min_value=lower,
+                max_value=upper,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+    return st.tuples(*strategies)
+
+
+_EVALUATOR_CLASSES = [HS100, Rosenbrock, Sphere, ConstrainedBetts]
+
+
+@pytest.mark.parametrize(
+    "evaluator_cls", _EVALUATOR_CLASSES, ids=lambda cls: cls.__name__
+)
+def test_compute_round_trip(evaluator_cls):
+    """Property 6: Compute Round Trip
+
+    For any TestEvaluator, when the component is constructed, set up in an
+    OpenMDAO problem, and run_model() is called with generated inputs within
+    variable bounds, the output values for every response SHALL match (within
+    relative tolerance 1e-10) the values obtained by invoking the same evaluator
+    directly with a DataFrame of the same inputs.
+
+    **Validates: Requirements 7.1, 7.2, 7.3, 8.2, 8.3**
+    """
+    evaluator = _create_evaluator_instance(evaluator_cls)
+    strategy = input_values_strategy(evaluator)
+
+    @given(input_vals=strategy)
+    @settings(max_examples=100, deadline=None)
+    def check_round_trip(input_vals):
+        # Create fresh OpenMDAO problem for each example
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        # Set input values from the generated tuple
+        var_names = [var.name for var in evaluator.opt_problem.variables]
+        for name, val in zip(var_names, input_vals):
+            prob.set_val(name, val)
+
+        # Run the model through OpenMDAO
+        prob.run_model()
+
+        # Call evaluator directly with same inputs as DataFrame
+        input_dict = {name: [val] for name, val in zip(var_names, input_vals)}
+        data_frame = pd.DataFrame(data=input_dict)
+        evaluator(data_frame)
+
+        # Assert all outputs match within 1e-10 tolerance
+        for response in evaluator.outputs:
+            om_value = prob.get_val(response).flatten()[0]
+            direct_value = float(data_frame[response].iloc[0])
+            np.testing.assert_allclose(
+                om_value,
+                direct_value,
+                rtol=1e-10,
+                err_msg=(
+                    f"Mismatch for response '{response}' with evaluator "
+                    f"{evaluator_cls.__name__}: OpenMDAO={om_value}, "
+                    f"Direct={direct_value}"
+                ),
+            )
+
+    check_round_trip()
+
+
+# ---------------------------------------------------------------------------
+# Strategies for Property 4
+# ---------------------------------------------------------------------------
+
+# Strategy for finite float values suitable for bounds
+_finite_floats = st.floats(
+    min_value=-1e10, max_value=1e10, allow_nan=False, allow_infinity=False
+)
+
+
+@st.composite
+def response_bounds_strategy(draw):
+    """Generate a tuple of (lower, upper) bounds with mix of finite/infinite.
+
+    Covers four cases:
+    - Both bounds finite (lower <= upper)
+    - Lower bound = -inf, upper finite
+    - Lower finite, upper = +inf
+    - Both bounds infinite
+    """
+    case = draw(st.sampled_from([
+        "both_finite", "lower_inf", "upper_inf", "both_inf"
+    ]))
+
+    if case == "both_finite":
+        lower = draw(_finite_floats)
+        upper = draw(_finite_floats.filter(lambda x: x >= lower))
+        return (lower, upper)
+    elif case == "lower_inf":
+        upper = draw(_finite_floats)
+        return (-np.inf, upper)
+    elif case == "upper_inf":
+        lower = draw(_finite_floats)
+        return (lower, np.inf)
+    else:  # both_inf
+        return (-np.inf, np.inf)
+
+
+@st.composite
+def response_variable_strategy(draw, name=None):
+    """Generate a FloatVariable suitable for use as a response."""
+    if name is None:
+        name = draw(
+            st.text(
+                alphabet=st.characters(
+                    whitelist_categories=("L",), whitelist_characters="_"
+                ),
+                min_size=1,
+                max_size=8,
+            ).filter(lambda s: s[0].isalpha() or s[0] == "_")
+        )
+    bounds = draw(response_bounds_strategy())
+    shift = draw(_finite_floats)
+    scale = draw(_finite_floats.filter(lambda x: x != 0.0))
+    return FloatVariable(
+        name=name,
+        bounds=bounds,
+        shift=shift,
+        scale=scale,
+        default=None,
+    )
+
+
+@st.composite
+def response_list_strategy(draw):
+    """Generate a list of 1-5 response FloatVariables with unique names."""
+    num_responses = draw(st.integers(min_value=1, max_value=5))
+    names = draw(
+        st.lists(
+            st.text(
+                alphabet=st.characters(
+                    whitelist_categories=("L",), whitelist_characters="_"
+                ),
+                min_size=1,
+                max_size=8,
+            ).filter(lambda s: s[0].isalpha() or s[0] == "_"),
+            min_size=num_responses,
+            max_size=num_responses,
+            unique=True,
+        )
+    )
+    responses = []
+    for name in names:
+        resp = draw(response_variable_strategy(name=name))
+        responses.append(resp)
+    return responses
+
+
+# ---------------------------------------------------------------------------
+# Property 4: Response-to-Output Bounds Mapping
+# Feature: openmdao-component-migration, Property 4: Response-to-Output Bounds Mapping
+# ---------------------------------------------------------------------------
+
+
+class DummyResponseEvaluator(Evaluator):
+    """Minimal evaluator for testing response-to-output bounds mapping."""
+
+    __test__ = False
+
+    def _evaluate(self, sites: pd.DataFrame) -> None:
+        for resp in self.opt_problem.responses:
+            sites[resp.name] = 0.0
+
+
+class TestResponseToOutputBoundsMapping:
+    """Property 4: Response-to-Output Bounds Mapping.
+
+    For any response Variable in opt_problem.responses, the OpenMDAO output
+    bounds SHALL be: the actual bound value when finite, or None when the
+    bound is infinite (-inf for lower, +inf for upper).
+
+    **Validates: Requirements 6.3, 6.4**
+    """
+
+    @given(responses=response_list_strategy())
+    @settings(max_examples=100, deadline=None)
+    def test_response_to_output_bounds_mapping(self, responses):
+        """Verify OpenMDAO output bounds are correct for generated responses.
+
+        For each response:
+        - If lower bound is finite, OpenMDAO lower should equal the bound value
+        - If lower bound is -inf, OpenMDAO lower should be None
+        - If upper bound is finite, OpenMDAO upper should equal the bound value
+        - If upper bound is +inf, OpenMDAO upper should be None
+        """
+        # Create a minimal opt_problem with one input variable and the
+        # generated responses
+        input_var = FloatVariable(
+            name="x_input", bounds=(-1.0, 1.0), default=0.0
+        )
+        opt_problem = OptProblem(
+            variables=[input_var],
+            responses=responses,
+        )
+
+        # Create evaluator and set up OpenMDAO problem
+        evaluator = DummyResponseEvaluator(opt_problem=opt_problem)
+
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "comp", EvaluatorOpenMdaoComponent(evaluator), promotes=["*"]
+        )
+        prob.setup()
+
+        # Verify bounds for each response
+        comp = prob.model.comp
+        meta = comp.get_io_metadata(iotypes="output")
+
+        for resp in responses:
+            lower_bound, upper_bound = resp.bounds
+
+            # Find the metadata entry for this response
+            output_key = None
+            for key in meta:
+                if key.endswith(f".{resp.name}") or key == resp.name:
+                    output_key = key
+                    break
+
+            assert output_key is not None, (
+                f"Response '{resp.name}' not found in component outputs"
+            )
+
+            output_meta = meta[output_key]
+
+            # Check lower bound: finite -> actual value, -inf -> None
+            if np.isfinite(lower_bound):
+                assert output_meta["lower"] == lower_bound, (
+                    f"Response '{resp.name}': expected lower={lower_bound}, "
+                    f"got {output_meta['lower']}"
+                )
+            else:
+                assert output_meta["lower"] is None, (
+                    f"Response '{resp.name}': expected lower=None for -inf, "
+                    f"got {output_meta['lower']}"
+                )
+
+            # Check upper bound: finite -> actual value, +inf -> None
+            if np.isfinite(upper_bound):
+                assert output_meta["upper"] == upper_bound, (
+                    f"Response '{resp.name}': expected upper={upper_bound}, "
+                    f"got {output_meta['upper']}"
+                )
+            else:
+                assert output_meta["upper"] is None, (
+                    f"Response '{resp.name}': expected upper=None for +inf, "
+                    f"got {output_meta['upper']}"
+                )

--- a/tests/components/test_pbt_evaluator_om_component.py
+++ b/tests/components/test_pbt_evaluator_om_component.py
@@ -6,8 +6,6 @@ wrapper across a range of inputs and evaluator configurations.
 # Feature: openmdao-component-migration
 """
 
-import copy
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -16,7 +14,6 @@ import openmdao.api as om
 from hypothesis import given, settings, assume
 from hypothesis import strategies as st
 
-import standard_evaluator as se
 from standard_evaluator.components import EvaluatorOpenMdaoComponent
 from standard_evaluator.evaluators.abstract_evaluator import Evaluator
 from standard_evaluator.evaluators.test import (


### PR DESCRIPTION
Migrate the OpenMDAO ExplicitComponent wrapper from boeing-standard-evaluator into the standard-evaluator library. The component wraps any Evaluator using the pydantic OptProblem API (variables/responses) instead of the legacy dict-based problem API.

- Implement EvaluatorOpenMdaoComponent with init, initialize, setup, compute
- Deep copy isolation, type checking, kwarg conflict detection
- SurrogateModel.from_dict fallback reconstruction path
- Variable-to-input mapping with defaults and bounds midpoint fallback
- Response-to-output mapping with bounds, scaling (ref0/ref), and validation
- 16 unit/integration tests covering error handling and end-to-end flows
- 10 property-based tests (Hypothesis) validating correctness properties
- All 26 tests passing

closes #91 