### PR TITLE
Add documentation notebooks, API reference, and validation tests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,12 @@
-name: Deploy to GitHub Pages
+name: Documentation
 
 on:
   push:
-    branches: [ "main" ]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: [ "main", "dev" ]
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches: [ "main", "dev" ]
   workflow_dispatch:
 
 permissions:
@@ -12,23 +14,17 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -37,20 +33,32 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[docs]
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
       - name: Build documentation
         run: |
           cd docs
           python -m sphinx -b html source ./_html
 
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_html
+          retention-days: 7
 
-      - name: Upload artifact
+      - name: Upload Pages artifact
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-pages-artifact@v5
         with:
-          path: 'docs/_html'
+          path: docs/_html
 
+  deploy:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,18 @@ docs/source/demos/.ipynb_checkpoints/*
 #docs/source/demos/demo_group.json
 #docs/source/demos/demo_group_NASA.json
 #docs/source/demos/state.h5
-#docs/source/demos/optproblem*.json
+docs/source/demos/optproblem*.json
 docs/_html
 docs/jupyter_execute
 
 scripts/
 __main__*
+test_nb*_out/
+test_notebook_code*_out/
+problem_out/
+experimenting/*.h5
+experimenting/*.html
+experimenting/assembly.json
+docs/build/
+docs/source/.cache/
+*.db

--- a/.kiro/specs/feature-documentation/.config.kiro
+++ b/.kiro/specs/feature-documentation/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "3c85b6fe-6b7e-4ccd-aa10-b5c72f3a2b7b", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/feature-documentation/design.md
+++ b/.kiro/specs/feature-documentation/design.md
@@ -1,0 +1,248 @@
+# Design Document: Feature Documentation
+
+## Overview
+
+This design covers the creation of comprehensive tutorial-style Jupyter notebook documentation and API reference pages for the Standard Evaluator library. The documentation will follow the existing MyST-NB Sphinx pattern established in `docs/source/demos/`, producing 6 new demo notebooks and a full API reference section.
+
+The design leverages the existing Sphinx infrastructure (autodoc, autodocsumm, myst_nb, napoleon) already configured in `conf.py`, and the established notebook pattern of alternating markdown/code cells with the `import standard_evaluator as se` convention.
+
+### Key Design Decisions
+
+1. **Notebooks over RST**: Tutorial content is delivered as executable Jupyter notebooks (`.ipynb`) rendered by MyST-NB, matching existing demos. This ensures examples are always runnable.
+2. **API Reference via autodoc**: The `reference/` section uses Sphinx `automodule`/`autoclass` directives with `autodocsumm`, generating documentation from source docstrings. No separate hand-written API docs.
+3. **Dependency isolation**: Notebooks 1, 3–6 use only base dependencies. Notebook 2 (surrogate models) requires `smt` extras and documents this prominently.
+4. **Single demos directory**: All new notebooks go into `docs/source/demos/` alongside existing ones, registered in the existing `demos/index.rst` toctree.
+
+## Architecture
+
+The documentation system is structured as follows:
+
+```mermaid
+graph TD
+    A[docs/source/index.rst] --> B[demos/index.rst]
+    A --> C[reference/index.rst]
+    B --> D[Existing 5 demos]
+    B --> E[6 New Demo Notebooks]
+    C --> F[evaluators.rst]
+    C --> G[surrogate_models.rst]
+    C --> H[components.rst]
+    C --> I[data_models.rst]
+    C --> J[decorators.rst]
+    
+    E --> E1[evaluator_hierarchy.ipynb]
+    E --> E2[surrogate_models.ipynb]
+    E --> E3[openmdao_component.ipynb]
+    E --> E4[array_variables.ipynb]
+    E --> E5[benchmark_problems.ipynb]
+    E --> E6[evaluator_interface.ipynb]
+```
+
+### Build Flow
+
+```mermaid
+flowchart LR
+    NB[.ipynb files] -->|myst_nb| SPHINX[Sphinx Build]
+    RST[.rst files] -->|autodoc| SPHINX
+    SPHINX --> HTML[HTML Documentation Site]
+```
+
+MyST-NB executes notebooks during the build (with caching via `jupyter_execute_notebooks = "cache"`) and renders them as HTML pages. The `reference/` RST files use `automodule` and `autoclass` directives to pull docstrings from source code.
+
+## Components and Interfaces
+
+### Demo Notebooks
+
+Each notebook follows the established pattern observed in `defining_options.ipynb`:
+
+| Component | Description |
+|-----------|-------------|
+| `evaluator_hierarchy.ipynb` | Evaluator class hierarchy, NumpyEvaluator usage, eval_np/eval_list, caching, logging |
+| `surrogate_models.ipynb` | SurrogateModel training, prediction, serialization round-trip, SMT models, options |
+| `openmdao_component.ipynb` | EvaluatorOpenMdaoComponent wrapping, variable mapping, serialization reconstruction |
+| `array_variables.ipynb` | ArrayVariable definition, rolled/unrolled usage, name generation, OpenMDAO integration |
+| `benchmark_problems.ipynb` | Benchmark test evaluators by category, evaluation, OptProblem access, known solutions |
+| `evaluator_interface.ipynb` | OptProblem vs EvaluatorInfo, variable types, NumpyEvaluator instantiation patterns |
+
+### Notebook Cell Pattern
+
+Every notebook follows this structure:
+1. **Cell 1** (markdown): Level-1 heading + overview paragraph
+2. **Cell 2** (code): Imports using `import standard_evaluator as se`
+3. **Cells 3–N** (alternating): Markdown introducing concept → Code demonstrating it → (optional) Markdown explaining output
+
+No two consecutive code cells without an intervening markdown cell.
+
+### API Reference Section
+
+The `docs/source/reference/` directory contains RST files using Sphinx autodoc:
+
+| File | Content |
+|------|---------|
+| `index.rst` | Toctree listing all reference sub-pages |
+| `evaluators.rst` | `autoclass` directives for Evaluator, NumpyEvaluator, ExecutableEvaluator, ShiftScaleEvaluator, OpenMDAOEvaluator, ExcelEvaluator, MatlabEvaluator |
+| `surrogate_models.rst` | `autoclass` directives for SurrogateModel, PolynomialModel, and SMT-based models |
+| `components.rst` | `autoclass` directive for EvaluatorOpenMdaoComponent |
+| `data_models.rst` | `autoclass` directives for OptProblem, EvaluatorInfo, GroupInfo, FloatVariable, IntVariable, ArrayVariable, CategoricalVariable |
+| `decorators.rst` | `automodule` directives for `standard_evaluator.evaluators.decorators.cache` and `standard_evaluator.evaluators.decorators.site_logger` |
+
+### Integration Points
+
+- **demos/index.rst**: Updated to include 6 new toctree entries after existing 5
+- **reference/index.rst**: New file referenced from `docs/source/index.rst` (already listed in the main index)
+- **conf.py**: No changes required — all needed extensions are already configured
+
+## Data Models
+
+### Notebook Structure (nbformat v4)
+
+Each `.ipynb` file is a JSON document conforming to nbformat v4:
+
+```json
+{
+  "cells": [
+    {
+      "cell_type": "markdown" | "code",
+      "metadata": {},
+      "source": ["line1\n", "line2\n"],
+      "outputs": [],          // code cells only
+      "execution_count": null // code cells only
+    }
+  ],
+  "metadata": {
+    "kernelspec": { "display_name": "Python 3", "language": "python", "name": "python3" },
+    "language_info": { "name": "python", "version": "3.11" }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}
+```
+
+### RST Reference Page Structure
+
+Each reference RST file follows this pattern:
+
+```rst
+Module Title
+============
+
+.. automodule:: standard_evaluator.module_path
+   :members:
+   :show-inheritance:
+
+.. autoclass:: standard_evaluator.module_path.ClassName
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+```
+
+### File Naming Convention
+
+| Notebook | Filename |
+|----------|----------|
+| Evaluator Hierarchy | `evaluator_hierarchy.ipynb` |
+| Surrogate Models | `surrogate_models.ipynb` |
+| OpenMDAO Component | `openmdao_component.ipynb` |
+| Array Variables | `array_variables.ipynb` |
+| Benchmark Problems | `benchmark_problems.ipynb` |
+| Evaluator Interface | `evaluator_interface.ipynb` |
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+> **Note on PBT applicability:** This feature primarily produces documentation artifacts (Jupyter notebooks and RST files). Most acceptance criteria concern content presence, structure conformance, and build success — which are best validated with example-based and integration tests. However, the structural invariants of notebooks do lend themselves to universal quantification over the set of all produced notebooks.
+
+### Property 1: Notebook Structure Invariant
+
+*For any* demo notebook produced by this feature, the notebook SHALL begin with a markdown cell containing a level-1 heading, followed by an overview paragraph, and SHALL contain no two consecutive code cells without an intervening markdown cell.
+
+**Validates: Requirements 8.1, 8.2, 8.7**
+
+### Property 2: Build Completeness
+
+*For any* notebook registered in the demos toctree, the Sphinx build SHALL complete with zero warnings and zero errors referencing that notebook file.
+
+**Validates: Requirements 7.3, 9.7**
+
+### Property 3: Notebook Execution Correctness
+
+*For any* demo notebook produced by this feature (given required dependencies are installed), executing all cells sequentially in a fresh kernel SHALL produce zero exceptions.
+
+**Validates: Requirements 1.7, 2.7, 3.5, 4.6, 5.5, 6.6**
+
+## Error Handling
+
+### Notebook Execution Errors
+
+| Error Condition | Handling Strategy |
+|----------------|-------------------|
+| Missing optional dependency (e.g., `smt`) | Notebook 2 includes a markdown cell before any SMT import stating `pip install standard-evaluator[smt]` is required. Other notebooks use only base dependencies. |
+| Import failure | Each notebook uses `import standard_evaluator as se` as the first code cell. If the package is not installed, the ImportError will surface immediately in the first cell. |
+| Evaluator runtime error | Code examples use known-good benchmark evaluators with valid input data constructed from `opt_problem.variables` bounds, avoiding invalid inputs. |
+| OpenMDAO setup failure | Notebooks 3 and 4 call `prob.setup()` before `prob.run_model()`. Any configuration errors surface at setup time with clear OpenMDAO error messages. |
+| Notebook execution timeout | `nb_execution_timeout = 600` in conf.py provides a 10-minute limit per cell. Notebook 2 is designed to complete within 120 seconds total. |
+
+### Sphinx Build Errors
+
+| Error Condition | Handling Strategy |
+|----------------|-------------------|
+| Missing notebook file in toctree | Sphinx emits a warning identifying the missing file. The toctree entries exactly match the filenames of created notebooks. |
+| Broken cross-reference in API docs | All `autoclass` directives reference importable Python paths. Undocumented members use `:undoc-members:` to avoid warnings. |
+| Missing docstring warning | The API reference pages use `:members:` which only documents members that have docstrings. Classes without docstrings are excluded from the reference. |
+
+## Testing Strategy
+
+### Approach
+
+Since this feature produces documentation artifacts, the testing strategy focuses on:
+
+1. **Notebook execution tests** — Verify each notebook runs without errors
+2. **Structure validation tests** — Verify notebooks follow required patterns
+3. **Sphinx build tests** — Verify documentation builds cleanly
+
+### Unit Tests (Example-Based)
+
+These verify specific structural requirements for each notebook:
+
+| Test | Validates |
+|------|-----------|
+| Each notebook starts with a level-1 markdown heading | Req 8.1 |
+| First markdown cell contains an overview paragraph | Req 8.2 |
+| No consecutive code cells without intervening markdown | Req 8.7 |
+| Import cells use `import standard_evaluator as se` | Req 8.5 |
+| Notebook 2 contains SMT install instruction before SMT usage | Req 8.6 |
+| demos/index.rst contains all 6 new entries in correct order | Req 7.1, 7.2 |
+| reference/index.rst exists and contains all sub-page entries | Req 9.6 |
+
+### Integration Tests
+
+| Test | Validates |
+|------|-----------|
+| `sphinx-build -W docs/source docs/build` completes with zero warnings | Req 7.3, 9.7 |
+| Each notebook executes without error in a fresh kernel | Req 1.7, 2.7, 3.5, 4.6, 5.5, 6.6 |
+| Notebook 2 completes within 120 seconds with `smt` installed | Req 2.7 |
+
+### Smoke Tests
+
+| Test | Validates |
+|------|-----------|
+| `python -c "import standard_evaluator as se"` succeeds | Base dependency check |
+| API reference pages render without "missing docstring" warnings | Req 9.7 |
+
+### Test Implementation
+
+Tests should be implemented using `pytest` with the `nbformat` library for notebook parsing and `subprocess` for Sphinx build invocation. Notebook execution tests use `nbconvert`'s `ExecutePreprocessor` or `jupyter execute` CLI.
+
+```python
+# Example test structure
+def test_notebook_structure(notebook_path):
+    """Verify notebook follows required cell pattern."""
+    nb = nbformat.read(notebook_path, as_version=4)
+    # First cell is markdown with level-1 heading
+    assert nb.cells[0].cell_type == "markdown"
+    assert nb.cells[0].source.startswith("# ")
+    # No consecutive code cells
+    for i in range(len(nb.cells) - 1):
+        if nb.cells[i].cell_type == "code":
+            assert nb.cells[i + 1].cell_type == "markdown"
+```

--- a/.kiro/specs/feature-documentation/requirements.md
+++ b/.kiro/specs/feature-documentation/requirements.md
@@ -1,0 +1,138 @@
+# Requirements Document
+
+## Introduction
+
+The Standard Evaluator library has added several major features (evaluator hierarchy, surrogate models, OpenMDAO component, array variables, benchmark test problems, simplified interface) that currently lack documentation. This feature delivers comprehensive tutorial-style Jupyter notebook documentation for all new capabilities, following the existing MyST-NB Sphinx documentation pattern established in the `docs/source/demos/` folder.
+
+## Glossary
+
+- **Documentation_System**: The Sphinx-based documentation build using MyST-NB that renders Jupyter notebooks as HTML pages in the project documentation site.
+- **Demo_Notebook**: A self-contained Jupyter notebook (`.ipynb`) located in `docs/source/demos/` that serves as both executable tutorial and rendered documentation page.
+- **Evaluator**: An abstract class defining the common API for wrapping analysis codes; accepts a pandas DataFrame of inputs and adds response columns in-place.
+- **NumpyEvaluator**: A concrete Evaluator subclass that wraps a user-defined NumPy function.
+- **Surrogate_Model**: A trained mathematical approximation of an Evaluator, supporting training from data, prediction, serialization, and Dask-parallel training.
+- **EvaluatorOpenMdaoComponent**: An OpenMDAO ExplicitComponent that wraps any Evaluator, mapping variables to inputs and responses to outputs.
+- **ArrayVariable**: A variable type representing multi-dimensional NumPy arrays with shape, bounds, shift, and scale.
+- **Benchmark_Evaluator**: A test evaluator implementing a known mathematical optimization problem, used for testing and demonstration.
+- **Demos_Index**: The Sphinx toctree file (`docs/source/demos/index.rst`) that lists all demo notebooks for inclusion in the documentation build.
+- **SE**: The standard import alias for `standard_evaluator` (`import standard_evaluator as se`).
+
+## Requirements
+
+### Requirement 1: Evaluator Hierarchy Documentation
+
+**User Story:** As a developer new to the Standard Evaluator library, I want a tutorial notebook explaining the evaluator hierarchy and how to create and use evaluators, so that I can understand the core abstraction and start wrapping my own analysis codes.
+
+#### Acceptance Criteria
+
+1. WHEN a user opens the evaluator hierarchy notebook, THE Demo_Notebook SHALL contain a markdown overview explaining the abstract Evaluator class, its subclasses (NumpyEvaluator, ExecutableEvaluator, ShiftScaleEvaluator, OpenMdaoEvaluator, ExcelEvaluator, MatlabEvaluator), and the decorator pattern (caching, logging).
+2. THE Demo_Notebook SHALL include a code example that creates a NumpyEvaluator from one of the benchmark test evaluators, builds an input DataFrame with at least 2 rows of input sites, calls the evaluator using the `__call__` method, and displays the resulting DataFrame showing both the original input columns and the appended response columns.
+3. THE Demo_Notebook SHALL include a working code example demonstrating the `eval_np` and `eval_list` developer convenience methods, with a markdown explanation that these methods exclude fixed variables from the input and unroll ArrayVariables into individual scalar columns (only the `__call__` method preserves array variables as arrays).
+4. THE Demo_Notebook SHALL include a working code example that applies the caching decorator to an evaluator by passing a `cache` parameter, evaluates at least one site, and then calls `get_cache()` to display the cached results.
+5. THE Demo_Notebook SHALL include a working code example that applies the logging decorator to an evaluator by passing `logging=True`, evaluates at least one site, and then calls `get_log()` to display the logged evaluation history.
+6. THE Demo_Notebook SHALL use the `import standard_evaluator as se` convention for all imports.
+7. THE Demo_Notebook SHALL be executable without errors in the project virtual environment using only the base required dependencies (no optional extras such as smt, aviary, or excel).
+
+### Requirement 2: Surrogate Model Documentation
+
+**User Story:** As a developer who wants to build surrogate models, I want a tutorial notebook explaining how to train, evaluate, and serialize surrogate models, so that I can approximate expensive evaluators with fast mathematical models.
+
+#### Acceptance Criteria
+
+1. WHEN a user opens the surrogate model notebook, THE Demo_Notebook SHALL contain a markdown overview that lists the SurrogateModel base class, PolynomialModel, and the SMT-based models (RBF, IDW, GENN, LS, RMTS, SOPA), stating each model's purpose and their inheritance hierarchy.
+2. THE Demo_Notebook SHALL include a working code example that trains a PolynomialModel on at least 10 sample sites generated from a test evaluator and predicts responses at a separate set of at least 3 new input sites, printing or displaying both predicted and true values.
+3. THE Demo_Notebook SHALL include a working code example that serializes a trained model using `to_dict`, reconstructs it using `from_dict`, and verifies that predictions from the reconstructed model match the original model's predictions on the same input sites.
+4. THE Demo_Notebook SHALL include a working code example that trains an SMT-based model (RBF) on at least 10 sample sites and displays a numerical accuracy metric (such as RMSE or R²) comparing the model's predictions to the true evaluator output on a separate set of test sites.
+5. THE Demo_Notebook SHALL include a markdown section explaining the options system for surrogate models, accompanied by a code example that creates a model with a non-default option value (e.g., polynomial degree or RBF regularization parameter) and shows the effect on predictions.
+6. THE Demo_Notebook SHALL include a markdown note indicating that SMT-based models require the `standard-evaluator[smt]` optional dependency installed via `pip install standard-evaluator[smt]`.
+7. THE Demo_Notebook SHALL exclude long-running SMT model training examples (such as those requiring extended fitting times) and SHALL be executable without errors and complete within 120 seconds when the `smt` optional dependency is installed.
+
+### Requirement 3: EvaluatorOpenMdaoComponent Documentation
+
+**User Story:** As an OpenMDAO user, I want a tutorial notebook showing how to wrap any Evaluator as an OpenMDAO component, so that I can integrate Standard Evaluator analyses into OpenMDAO models.
+
+#### Acceptance Criteria
+
+1. WHEN a user opens the OpenMDAO component notebook, THE Demo_Notebook SHALL contain at least one markdown cell explaining the purpose of EvaluatorOpenMdaoComponent, the mapping from OptProblem variables to OpenMDAO inputs, and the mapping from OptProblem responses to OpenMDAO outputs.
+2. THE Demo_Notebook SHALL include a code example that defines an OptProblem with at least two variables and one response, creates a NumpyEvaluator, wraps it in an EvaluatorOpenMdaoComponent, adds the component to an OpenMDAO Problem, runs the model, and prints the computed output values.
+3. THE Demo_Notebook SHALL include a code example that retrieves and displays the OpenMDAO input metadata (default values, bounds) and output metadata (bounds, scaling) of the EvaluatorOpenMdaoComponent to show how OptProblem definitions map to OpenMDAO variable properties.
+4. THE Demo_Notebook SHALL include a code example that calls `to_dict` on the evaluator to obtain serialized options, constructs a new EvaluatorOpenMdaoComponent by passing those options as the `evaluator_options` keyword argument, runs the reconstructed component in an OpenMDAO Problem, and prints output values matching those of the original component.
+5. THE Demo_Notebook SHALL be executable without errors in the project virtual environment using only the required dependencies defined in the project configuration.
+
+### Requirement 4: Array Variable Documentation
+
+**User Story:** As a developer working with multi-dimensional inputs and outputs, I want a tutorial notebook explaining how to define and use ArrayVariables, so that I can model vector and matrix quantities in my evaluators.
+
+#### Acceptance Criteria
+
+1. WHEN a user opens the array variable notebook, THE Demo_Notebook SHALL contain a markdown overview explaining the ArrayVariable type, its fields (shape, bounds, shift, scale, default, units), its relationship to FloatVariable, and the distinction between rolled (single NumPy array in a DataFrame cell) and unrolled (individual scalar columns) representations.
+2. THE Demo_Notebook SHALL include a working code example that creates at least one 1-D ArrayVariable (shape with a single dimension) and at least one 2-D ArrayVariable (shape with two dimensions), each with explicitly set bounds.
+3. THE Demo_Notebook SHALL include a working code example that creates a NumpyEvaluator using ArrayVariable inputs and outputs, invokes it via `__call__` with rolled array data in a DataFrame, and invokes it via `eval_np` with unrolled data, displaying results from both calls.
+4. THE Demo_Notebook SHALL include a working code example that instantiates an EvaluatorOpenMdaoComponent with an evaluator that uses ArrayVariable inputs and outputs, calls `setup()` on an OpenMDAO Problem containing the component, and verifies the component runs `compute` without errors.
+5. THE Demo_Notebook SHALL include a markdown section explaining the name generation pattern for unrolled array variables, covering both 1-D arrays (e.g., `input[0]`, `input[1]`) and multi-dimensional arrays (e.g., `matrix[0,0]`, `matrix[0,1]`, `matrix[1,0]`).
+6. THE Demo_Notebook SHALL contain all specified content (overview, code examples, explanations) and SHALL be executable without errors by running all cells sequentially in a fresh kernel using the project virtual environment with the standard `pip install -e .` dependencies and the `openmdao` package installed.
+
+### Requirement 5: Benchmark Test Problems Documentation
+
+**User Story:** As a researcher or developer testing optimization algorithms, I want a tutorial notebook listing and demonstrating the available benchmark test evaluators, so that I can select appropriate test problems for my work.
+
+#### Acceptance Criteria
+
+1. WHEN a user opens the benchmark problems notebook, THE Demo_Notebook SHALL contain a markdown overview listing all available benchmark test evaluators organized by category (unconstrained, constrained, multi-fidelity, feasibility-discovery), with each entry showing the evaluator class name and number of design variables.
+2. THE Demo_Notebook SHALL include a working code example that instantiates at least three different benchmark evaluators (one unconstrained, one constrained, one feasibility-discovery), evaluates each at a minimum of 2 sample points provided as a pandas DataFrame, and displays the resulting output DataFrame including response columns.
+3. THE Demo_Notebook SHALL include a markdown description of each of the five feasibility-discovery benchmarks (SmallCircleFeasibleRegion, DisconnectedFeasibleRegions, G6Problem, G7Problem, SpeedReducer), where each description states the number of design variables, the number of constraints, and the purpose of the problem (what feasibility challenge it represents).
+4. THE Demo_Notebook SHALL include a working code example that accesses the OptProblem of a benchmark evaluator and prints its variables (names and bounds), responses (names), objectives, and constraints.
+5. THE Demo_Notebook SHALL be executable without errors in the project virtual environment using only required dependencies listed in the project's pyproject.toml.
+6. THE Demo_Notebook SHALL include a working code example that retrieves the known_solution property of at least one benchmark evaluator and displays the resulting DataFrame containing optimal input values and corresponding response values.
+
+### Requirement 6: Evaluator Interface Documentation
+
+**User Story:** As a developer, I want a tutorial notebook explaining how to define the interface for an evaluator using OptProblem and EvaluatorInfo, so that I can properly configure evaluators with typed variables, bounds, and metadata.
+
+#### Acceptance Criteria
+
+1. WHEN a user opens the evaluator interface notebook, THE Demo_Notebook SHALL contain a markdown overview explaining the two supported ways to define an evaluator interface: via `OptProblem` (for optimization problems with objectives and constraints) and via `EvaluatorInfo` (for general input/output descriptions).
+2. THE Demo_Notebook SHALL include a code example that creates an OptProblem with at least 2 FloatVariable inputs (each specifying name and bounds), at least 1 FloatVariable response, and defines at least one objective and one constraint referencing valid response names, and executes without error.
+3. THE Demo_Notebook SHALL include a code example that creates an EvaluatorInfo with at least 2 typed inputs and at least 1 typed output using Variable types from the supported union (FloatVariable, IntVariable, ArrayVariable, or CategoricalVariable), and uses it to instantiate a NumpyEvaluator by passing it as the `interface` parameter, executing without error.
+4. THE Demo_Notebook SHALL include a code example that creates a NumpyEvaluator using an OptProblem passed as the `opt_problem` parameter, calls the evaluator with a pandas DataFrame containing valid input values, and accesses the `inputs` and `outputs` properties to retrieve the list of variable names and response names respectively.
+5. THE Demo_Notebook SHALL include a markdown section explaining when to use OptProblem versus EvaluatorInfo, stating that OptProblem is used when objectives and constraints are defined for optimization, and EvaluatorInfo is used for general-purpose evaluators that only require input/output descriptions.
+6. THE Demo_Notebook SHALL be executable without errors in the project virtual environment using only required dependencies.
+
+### Requirement 7: Documentation Index Integration
+
+**User Story:** As a documentation maintainer, I want all new demo notebooks registered in the Sphinx toctree, so that they appear in the built documentation site navigation.
+
+#### Acceptance Criteria
+
+1. WHEN the documentation is built, THE Demos_Index SHALL include one toctree entry for each of the following 6 new demo notebooks: evaluator hierarchy, surrogate models, OpenMDAO component, array variables, benchmark problems, and evaluator interface, such that each entry renders as a navigation link in the built HTML site.
+2. THE Demos_Index SHALL list the new demo notebook entries after the existing entries (Problem_explanation, defining_options, group_creation_NASA, group_manipulation, group_reading) in the toctree directive, in the following order: evaluator hierarchy, surrogate models, OpenMDAO component, array variables, benchmark problems, evaluator interface.
+3. WHEN the Sphinx build command is executed, THE Documentation_System SHALL complete with zero warnings and zero errors referencing any of the 6 new notebook files.
+4. IF a new notebook file referenced in the toctree does not exist in the demos directory, THEN THE Documentation_System SHALL produce a Sphinx build warning identifying the missing file.
+
+### Requirement 8: Notebook Consistency Standards
+
+**User Story:** As a documentation maintainer, I want all new notebooks to follow a consistent style matching the existing demos, so that the documentation has a uniform appearance and quality.
+
+#### Acceptance Criteria
+
+1. THE Demo_Notebook SHALL begin with a level-1 markdown heading stating the notebook title.
+2. THE Demo_Notebook SHALL include an Overview paragraph in the first markdown cell, directly below the level-1 heading, explaining what the notebook demonstrates and what the reader will learn.
+3. THE Demo_Notebook SHALL include a markdown cell before each code cell that introduces a new concept, operation, or step, describing what the following code does or why it is needed.
+4. THE Demo_Notebook SHALL include a markdown cell after any code cell whose output contains numeric results, warnings, or data structures that require interpretation to explain what the output represents.
+5. THE Demo_Notebook SHALL use the `import standard_evaluator as se` convention as the primary import pattern.
+6. IF a notebook requires an optional dependency, THEN THE Demo_Notebook SHALL state the required install command (e.g., `pip install standard-evaluator[smt]`) in a markdown cell before the first code cell that uses the dependency. IF a notebook uses an optional dependency without a preceding install command, THEN the notebook SHALL fail validation.
+7. THE Demo_Notebook SHALL contain no consecutive code cells without an intervening markdown cell that provides context or transitions between them.
+
+### Requirement 9: API Reference Documentation
+
+**User Story:** As a developer integrating the Standard Evaluator library into my project, I want comprehensive API reference documentation for all public classes, so that I can understand the constructor signatures, methods, properties, and options of each component without reading the source code.
+
+#### Acceptance Criteria
+
+1. THE Documentation_System SHALL include an API reference section that documents all public classes in the evaluator hierarchy (Evaluator, NumpyEvaluator, ExecutableEvaluator, ShiftScaleEvaluator, OpenMdaoEvaluator, ExcelEvaluator, MatlabEvaluator), where each class page includes at minimum: a class description, constructor parameters with types, all public methods with signatures and parameter descriptions, and all public properties.
+2. THE Documentation_System SHALL include an API reference section that documents all public classes in the surrogate model hierarchy (SurrogateModel, PolynomialModel, RBFModel, IDWModel, GENNModel, LSModel, RMTSModel, SOPAModel), where each class page includes at minimum: a class description, constructor parameters with types, all public methods with signatures and parameter descriptions, and all public properties.
+3. THE Documentation_System SHALL include an API reference section that documents the EvaluatorOpenMdaoComponent class, where the page includes at minimum: a class description, constructor parameters with types, all public methods with signatures and parameter descriptions, and all public properties.
+4. THE Documentation_System SHALL include an API reference section that documents the data model classes (OptProblem, EvaluatorInfo, GroupInfo, FloatVariable, IntVariable, ArrayVariable, CategoricalVariable), where each class page includes at minimum: a class description, all fields/attributes with types and descriptions, and all public methods.
+5. THE Documentation_System SHALL include an API reference section that documents the decorator modules (caching, logging), where the page includes at minimum: a description of the decorator's purpose, function signature, accepted parameters, and return type.
+6. WHEN the Sphinx documentation is built, THE Documentation_System SHALL auto-generate API reference pages from the source docstrings using Sphinx autodoc (autoclass directives) with the `autodocsumm` extension, producing one dedicated page per class that includes inherited members, method summaries, and attribute summaries. IF autodoc is disabled or unavailable, THEN the Sphinx build SHALL fail with an error indicating that autodoc is required for API reference generation.
+7. THE Documentation_System SHALL build the API reference producing zero Sphinx warnings or errors of type "missing docstring" or "broken cross-reference" across all pages in the reference section.

--- a/.kiro/specs/feature-documentation/tasks.md
+++ b/.kiro/specs/feature-documentation/tasks.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Feature Documentation
+
+## Overview
+
+Create comprehensive tutorial-style Jupyter notebook documentation and API reference pages for the Standard Evaluator library. This involves creating 6 new demo notebooks in `docs/source/demos/`, a new `docs/source/reference/` API section, and updating the demos index toctree. All notebooks use the `import standard_evaluator as se` convention and follow the alternating markdown/code cell pattern.
+
+## Tasks
+
+- [x] 1. Create the API reference directory and index
+  - [x] 1.1 Create `docs/source/reference/index.rst` with toctree listing all API sub-pages (evaluators, surrogate_models, components, data_models, decorators)
+    - The `docs/source/index.rst` already references `reference/index`
+    - Create the directory and toctree file
+    - _Requirements: 9.6_
+
+  - [x] 1.2 Create `docs/source/reference/evaluators.rst` with autoclass directives for all evaluator classes
+    - Include: Evaluator, NumpyEvaluator, ExecutableEvaluator, ShiftScaleEvaluator, OpenMDAOEvaluator, ExcelEvaluator, MatlabEvaluator
+    - Use `autoclass` with `:members:`, `:show-inheritance:`, `:special-members: __init__, __call__`
+    - _Requirements: 9.1_
+
+  - [x] 1.3 Create `docs/source/reference/surrogate_models.rst` with autoclass directives for all surrogate model classes
+    - Include: SurrogateModel, PolynomialModel, RBFModel (RadialBasisFunctionModel), IDWModel (InverseDistanceWeightingModel), GENNModel, LSModel, RMTSModel, SOPAModel
+    - _Requirements: 9.2_
+
+  - [x] 1.4 Create `docs/source/reference/components.rst` with autoclass directive for EvaluatorOpenMdaoComponent
+    - _Requirements: 9.3_
+
+  - [x] 1.5 Create `docs/source/reference/data_models.rst` with autoclass directives for data model classes
+    - Include: OptProblem, EvaluatorInfo, GroupInfo, FloatVariable, IntVariable, ArrayVariable, CategoricalVariable
+    - _Requirements: 9.4_
+
+  - [x] 1.6 Create `docs/source/reference/decorators.rst` with automodule directives for decorator modules
+    - Include: `standard_evaluator.evaluators.decorators.cache`, `standard_evaluator.evaluators.decorators.site_logger`
+    - _Requirements: 9.5_
+
+- [x] 2. Create the evaluator hierarchy demo notebook
+  - [x] 2.1 Create `docs/source/demos/evaluator_hierarchy.ipynb` with markdown overview of Evaluator class hierarchy and code examples
+    - Start with level-1 heading "Evaluator Hierarchy" and overview paragraph
+    - Include markdown explaining abstract Evaluator class, subclasses (NumpyEvaluator, ExecutableEvaluator, ShiftScaleEvaluator, OpenMdaoEvaluator, ExcelEvaluator, MatlabEvaluator), and decorators
+    - Code example: create a NumpyEvaluator from a benchmark test evaluator, build DataFrame with ≥2 rows, call via `__call__`, display results
+    - Code example: demonstrate `eval_np` and `eval_list` with markdown explaining they exclude fixed variables and unroll ArrayVariables
+    - Code example: apply caching decorator via `cache` parameter, evaluate, call `get_cache()`
+    - Code example: apply logging decorator via `logging=True`, evaluate, call `get_log()`
+    - Use `import standard_evaluator as se` convention throughout
+    - Must run with base dependencies only (no smt, aviary, or excel extras)
+    - Ensure alternating markdown/code cells with no consecutive code cells
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 8.1, 8.2, 8.3, 8.4, 8.5, 8.7_
+
+- [x] 3. Create the surrogate model demo notebook
+  - [x] 3.1 Create `docs/source/demos/surrogate_models.ipynb` with surrogate model training, prediction, serialization, and options examples
+    - Start with level-1 heading "Surrogate Models" and overview paragraph
+    - Include markdown note about `pip install standard-evaluator[smt]` before any SMT import
+    - Markdown overview listing SurrogateModel base, PolynomialModel, SMT models (RBF, IDW, GENN, LS, RMTS, SOPA) with inheritance hierarchy
+    - Code example: train PolynomialModel on ≥10 sites from a test evaluator, predict at ≥3 new sites, display predicted vs true
+    - Code example: serialize with `to_dict`, reconstruct with `from_dict`, verify predictions match
+    - Code example: train RBF model on ≥10 sites, display accuracy metric (RMSE or R²)
+    - Markdown section explaining options system + code example with non-default option value
+    - Must complete within 120 seconds with smt installed
+    - Ensure alternating markdown/code cells
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7_
+
+- [x] 4. Create the OpenMDAO component demo notebook
+  - [x] 4.1 Create `docs/source/demos/openmdao_component.ipynb` with EvaluatorOpenMdaoComponent wrapping and variable mapping examples
+    - Start with level-1 heading "OpenMDAO Component Integration" and overview paragraph
+    - Markdown explaining purpose of EvaluatorOpenMdaoComponent, variable-to-input and response-to-output mapping
+    - Code example: define OptProblem with ≥2 variables and 1 response, create NumpyEvaluator, wrap in EvaluatorOpenMdaoComponent, add to OpenMDAO Problem, run model, print outputs
+    - Code example: retrieve and display OpenMDAO input/output metadata (defaults, bounds, scaling)
+    - Code example: call `to_dict` on evaluator, construct new component via `evaluator_options` kwarg, run, verify outputs match
+    - Must run with base dependencies (openmdao is in required dependencies)
+    - Ensure alternating markdown/code cells
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 8.1, 8.2, 8.3, 8.4, 8.5, 8.7_
+
+- [x] 5. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 6. Create the array variables demo notebook
+  - [x] 6.1 Create `docs/source/demos/array_variables.ipynb` with ArrayVariable definition, rolled/unrolled usage, and OpenMDAO integration
+    - Start with level-1 heading "Array Variables" and overview paragraph
+    - Markdown overview explaining ArrayVariable fields (shape, bounds, shift, scale, default, units), relationship to FloatVariable, rolled vs unrolled representations
+    - Code example: create 1-D ArrayVariable and 2-D ArrayVariable with explicit bounds
+    - Code example: create NumpyEvaluator with ArrayVariable inputs/outputs, invoke via `__call__` (rolled) and `eval_np` (unrolled), display both
+    - Code example: instantiate EvaluatorOpenMdaoComponent with array evaluator, setup OpenMDAO Problem, verify compute runs
+    - Markdown section explaining unrolled name generation: 1-D (`input[0]`, `input[1]`) and multi-D (`matrix[0,0]`, `matrix[0,1]`)
+    - Must run with base dependencies + openmdao
+    - Ensure alternating markdown/code cells
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 8.1, 8.2, 8.3, 8.4, 8.5, 8.7_
+
+- [x] 7. Create the benchmark problems demo notebook
+  - [x] 7.1 Create `docs/source/demos/benchmark_problems.ipynb` with benchmark evaluator catalog, evaluation, and known solutions
+    - Start with level-1 heading "Benchmark Test Problems" and overview paragraph
+    - Markdown listing all benchmark evaluators by category (unconstrained, constrained, multi-fidelity, feasibility-discovery) with class names and number of design variables
+    - Code example: instantiate ≥3 benchmarks (one unconstrained, one constrained, one feasibility-discovery), evaluate at ≥2 sample points, display output DataFrames
+    - Markdown describing the 5 feasibility-discovery benchmarks (SmallCircleFeasibleRegion, DisconnectedFeasibleRegions, G6Problem, G7Problem, SpeedReducer) with variable count, constraints, and purpose
+    - Code example: access OptProblem of a benchmark, print variables (names/bounds), responses, objectives, constraints
+    - Code example: retrieve `known_solution` property of a benchmark, display DataFrame
+    - Must run with base dependencies only
+    - Ensure alternating markdown/code cells
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 8.1, 8.2, 8.3, 8.4, 8.5, 8.7_
+
+- [x] 8. Create the evaluator interface demo notebook
+  - [x] 8.1 Create `docs/source/demos/evaluator_interface.ipynb` with OptProblem and EvaluatorInfo usage patterns
+    - Start with level-1 heading "Evaluator Interface" and overview paragraph
+    - Markdown explaining two interface approaches: OptProblem (for optimization with objectives/constraints) vs EvaluatorInfo (general I/O descriptions)
+    - Code example: create OptProblem with ≥2 FloatVariable inputs (name + bounds), ≥1 response, one objective, one constraint
+    - Code example: create EvaluatorInfo with ≥2 typed inputs and ≥1 output using Variable types, instantiate NumpyEvaluator via `interface` parameter
+    - Code example: create NumpyEvaluator with OptProblem via `opt_problem` parameter, call evaluator, access `inputs` and `outputs` properties
+    - Markdown section on when to use OptProblem vs EvaluatorInfo
+    - Must run with base dependencies only
+    - Ensure alternating markdown/code cells
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 8.1, 8.2, 8.3, 8.4, 8.5, 8.7_
+
+- [x] 9. Update the demos index toctree
+  - [x] 9.1 Update `docs/source/demos/index.rst` to add 6 new notebook entries after existing entries
+    - Add entries in order: evaluator_hierarchy, surrogate_models, openmdao_component, array_variables, benchmark_problems, evaluator_interface
+    - Place after existing entries (Problem_explanation, defining_options, group_creation_NASA, group_manipulation, group_reading)
+    - _Requirements: 7.1, 7.2_
+
+- [x] 10. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 11. Write notebook structure validation tests
+  - [x] 11.1 Write property test for notebook structure invariant
+    - **Property 1: Notebook Structure Invariant**
+    - **Validates: Requirements 8.1, 8.2, 8.7**
+    - Test that all 6 notebooks start with markdown cell containing level-1 heading, have overview paragraph, and contain no consecutive code cells
+
+  - [x] 11.2 Write integration test for Sphinx build completeness
+    - **Property 2: Build Completeness**
+    - **Validates: Requirements 7.3, 9.7**
+    - Run `sphinx-build -W` and verify zero warnings/errors for new notebooks and reference pages
+
+  - [x] 11.3 Write integration test for notebook execution correctness
+    - **Property 3: Notebook Execution Correctness**
+    - **Validates: Requirements 1.7, 2.7, 3.5, 4.6, 5.5, 6.6**
+    - Execute each notebook in a fresh kernel using `nbconvert` ExecutePreprocessor and verify zero exceptions
+
+- [x] 12. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- The API reference section (task 1) is independent of the demo notebooks (tasks 2–8) and can be built in parallel
+- All notebooks use `import standard_evaluator as se` as the primary import pattern
+- Only notebook 2 (surrogate_models) requires the `smt` optional dependency; all others use base dependencies
+- The `reference/` directory does not yet exist and must be created as part of task 1
+- Notebook content should use benchmark test evaluators from `se.evaluators.test` for examples
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "2.1", "3.1"] },
+    { "id": 1, "tasks": ["1.2", "1.3", "1.4", "1.5", "1.6", "4.1"] },
+    { "id": 2, "tasks": ["6.1", "7.1", "8.1"] },
+    { "id": 3, "tasks": ["9.1"] },
+    { "id": 4, "tasks": ["11.1", "11.2", "11.3"] }
+  ]
+}
+```

--- a/.kiro/steering/python-environment.md
+++ b/.kiro/steering/python-environment.md
@@ -2,28 +2,61 @@
 inclusion: auto
 ---
 
-# Python Environment
+# Python Environment — MANDATORY RULES
+
+These rules are NON-NEGOTIABLE. Every Python command MUST use the virtual environment executable. Violations cause failures because system Python does not have the project dependencies installed.
 
 ## Virtual Environment
 
-Always use the project virtual environment when running Python commands.
-
 - **Python executable**: `.venv\Scripts\python.exe`
 - **Working directory**: `c:\dev\standard-evaluator`
+- **Platform**: Windows (cmd shell)
 
-## Rules
+## FORBIDDEN Commands (NEVER use these)
 
-- NEVER use `python`, `python3`, `py`, or any system Python directly.
-- NEVER use `.venv\Scripts\activate` — use the full path to the executable instead.
-- For running scripts: `.venv\Scripts\python.exe script.py`
-- For running modules: `.venv\Scripts\python.exe -m module_name`
-- For running pytest: `.venv\Scripts\python.exe -m pytest`
-- For pip installs: `.venv\Scripts\python.exe -m pip install ...`
-
-## Examples
-
-```cmd
-.venv\Scripts\python.exe -m pytest tests/
-.venv\Scripts\python.exe -m pip install -e .
-.venv\Scripts\python.exe -c "import standard_evaluator; print('ok')"
 ```
+python ...          ← WRONG: uses system Python
+python3 ...        ← WRONG: doesn't exist on Windows
+py ...             ← WRONG: uses system Python
+pytest ...         ← WRONG: uses system pytest (may not exist)
+pip ...            ← WRONG: uses system pip
+.venv\Scripts\activate  ← WRONG: activate doesn't persist across commands
+```
+
+## REQUIRED Commands (ALWAYS use these)
+
+| Task | Command |
+|------|---------|
+| Run pytest | `.venv\Scripts\python.exe -m pytest tests/` |
+| Run specific test file | `.venv\Scripts\python.exe -m pytest tests/test_foo.py -v` |
+| Run pytest with markers | `.venv\Scripts\python.exe -m pytest -m "not slow" tests/` |
+| Run a script | `.venv\Scripts\python.exe script.py` |
+| Run a module | `.venv\Scripts\python.exe -m module_name` |
+| Pip install | `.venv\Scripts\python.exe -m pip install ...` |
+| Quick Python check | `.venv\Scripts\python.exe -c "import standard_evaluator"` |
+| Run nbconvert | `.venv\Scripts\python.exe -m nbconvert ...` |
+| Run sphinx | `.venv\Scripts\python.exe -m sphinx ...` |
+
+## Pytest Conventions
+
+- Test files live in `tests/` at the project root
+- Test file names: `test_*.py`
+- Use `pytest.mark.slow` for tests that take >10 seconds
+- Use `pytest.mark.integration` for tests requiring external tools (sphinx, nbconvert)
+- Use `pytest.importorskip("module")` for optional dependency tests
+- Use `-x` flag to stop on first failure when debugging
+- Use `-v` flag for verbose output when you need to see individual test names
+- Do NOT use `--timeout` (plugin not installed)
+
+## Notebook Execution
+
+When executing Jupyter notebooks programmatically:
+- Use `nbformat` + `nbclient` or `nbconvert.preprocessors.ExecutePreprocessor`
+- Set `kernel_name="python3"` (this refers to the kernel spec name, not the executable)
+- The kernel will use whatever Python is registered as the `python3` kernel (which is the venv Python)
+
+## Import Convention
+
+- Always use `import standard_evaluator as se` as the primary import in notebooks and examples
+- For internal modules, use full paths: `from standard_evaluator.evaluators.numpy_evaluator import NumpyEvaluator`
+- Read existing source code BEFORE writing code that calls library APIs — verify constructor signatures, method names, and parameter names match the actual implementation

--- a/docs/source/demos/array_variables.ipynb
+++ b/docs/source/demos/array_variables.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Array Variables\n",
+    "\n",
+    "This notebook demonstrates how to define and use `ArrayVariable` for multi-dimensional inputs and outputs in the Standard Evaluator library. You will learn how `ArrayVariable` extends `FloatVariable` with shape information, how array data is represented in both rolled (NumPy array in a DataFrame cell) and unrolled (individual scalar columns) forms, and how array evaluators integrate with OpenMDAO."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## Overview: ArrayVariable Fields and Concepts\n",
+    "\n",
+    "`ArrayVariable` is a subclass of `FloatVariable` that represents multi-dimensional NumPy arrays. It adds the following fields:\n",
+    "\n",
+    "| Field | Type | Description |\n",
+    "| ----- | ---- | ----------- |\n",
+    "| `shape` | `tuple[int, ...]` | Shape of the array (e.g., `(3,)` for 1-D, `(2, 3)` for 2-D) |\n",
+    "| `bounds` | `tuple[array, array]` | Lower and upper bounds — can be scalar (broadcast to shape) or full arrays |\n",
+    "| `shift` | `float \\| array` | Shift value(s) for the variable (broadcast to shape if scalar) |\n",
+    "| `scale` | `float \\| array` | Scale value(s) for the variable (broadcast to shape if scalar, cannot be zero) |\n",
+    "| `default` | `ndarray` | Default values as a NumPy array matching the shape |\n",
+    "| `units` | `str` | Units of the variable |\n",
+    "\n",
+    "### Relationship to FloatVariable\n",
+    "\n",
+    "`ArrayVariable` inherits from `FloatVariable` and reuses its name validation and general structure, but replaces scalar bounds/shift/scale with array-aware versions. While a `FloatVariable` represents a single scalar value, an `ArrayVariable` represents an entire NumPy array as a single logical variable.\n",
+    "\n",
+    "### Rolled vs Unrolled Representations\n",
+    "\n",
+    "- **Rolled**: The array is stored as a single NumPy array inside one DataFrame cell. This is what the `__call__` method expects and returns.\n",
+    "- **Unrolled**: Each element of the array becomes its own scalar column (e.g., `arr[0]`, `arr[1]`, `arr[2]` for a shape `(3,)` array). This is how `eval_np` and `eval_list` receive and return data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We import the Standard Evaluator library and supporting packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import standard_evaluator as se\n",
+    "from standard_evaluator.evaluators.numpy_evaluator import NumpyEvaluator\n",
+    "from standard_evaluator.components import EvaluatorOpenMdaoComponent\n",
+    "import openmdao.api as om\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## Creating ArrayVariables\n",
+    "\n",
+    "We create a 1-D `ArrayVariable` representing a 3-element vector and a 2-D `ArrayVariable` representing a 2×3 matrix. Both have explicit bounds set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1-D ArrayVariable: a vector of length 3\n",
+    "vec_var = se.ArrayVariable(\n",
+    "    name=\"vec\",\n",
+    "    shape=(3,),\n",
+    "    bounds=(-10.0, 10.0),\n",
+    "    default=np.array([1.0, 2.0, 3.0]),\n",
+    ")\n",
+    "\n",
+    "print(\"1-D ArrayVariable:\")\n",
+    "print(f\"  Name: {vec_var.name}\")\n",
+    "print(f\"  Shape: {vec_var.shape}\")\n",
+    "print(f\"  Bounds lower: {vec_var.bounds[0]}\")\n",
+    "print(f\"  Bounds upper: {vec_var.bounds[1]}\")\n",
+    "print(f\"  Default: {vec_var.default}\")\n",
+    "print()\n",
+    "\n",
+    "# 2-D ArrayVariable: a 2x3 matrix\n",
+    "mat_var = se.ArrayVariable(\n",
+    "    name=\"matrix\",\n",
+    "    shape=(2, 3),\n",
+    "    bounds=(0.0, 100.0),\n",
+    "    default=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),\n",
+    ")\n",
+    "\n",
+    "print(\"2-D ArrayVariable:\")\n",
+    "print(f\"  Name: {mat_var.name}\")\n",
+    "print(f\"  Shape: {mat_var.shape}\")\n",
+    "print(f\"  Bounds lower:\\n{mat_var.bounds[0]}\")\n",
+    "print(f\"  Bounds upper:\\n{mat_var.bounds[1]}\")\n",
+    "print(f\"  Default:\\n{mat_var.default}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "source": [
+    "The scalar bounds `(-10.0, 10.0)` and `(0.0, 100.0)` are automatically broadcast to match the array shape. You can also pass full NumPy arrays for per-element bounds."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "source": [
+    "## Using ArrayVariables in a NumpyEvaluator\n",
+    "\n",
+    "We define an evaluator that takes a 3-element vector input and produces a 3-element vector output by squaring each element. This demonstrates how `__call__` (rolled) and `eval_np` (unrolled) handle array data differently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the optimization problem with array input and output\n",
+    "opt_problem = se.OptProblem(\n",
+    "    name=\"array_demo\",\n",
+    "    variables=[\n",
+    "        se.ArrayVariable(\n",
+    "            name=\"x\",\n",
+    "            shape=(3,),\n",
+    "            bounds=(-5.0, 5.0),\n",
+    "            default=np.array([1.0, 2.0, 3.0]),\n",
+    "        ),\n",
+    "    ],\n",
+    "    responses=[\n",
+    "        se.ArrayVariable(\n",
+    "            name=\"y\",\n",
+    "            shape=(3,),\n",
+    "            bounds=(-np.inf, np.inf),\n",
+    "        ),\n",
+    "    ],\n",
+    "    objectives=[],\n",
+    "    constraints=[],\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Implement the evaluator: y = x^2 (element-wise)\n",
+    "class SquareArray(NumpyEvaluator):\n",
+    "    \"\"\"Computes y = x^2 element-wise for a 3-element vector.\"\"\"\n",
+    "\n",
+    "    def eval_np(self, sites, **kwargs):\n",
+    "        # sites is unrolled: shape (n_sites, 3) where columns are x[0], x[1], x[2]\n",
+    "        return sites ** 2\n",
+    "\n",
+    "\n",
+    "evaluator = SquareArray(opt_problem=opt_problem)\n",
+    "print(\"Inputs:\", evaluator.inputs)\n",
+    "print(\"Outputs:\", evaluator.outputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "### Rolled Invocation via `__call__`\n",
+    "\n",
+    "With `__call__`, we pass a DataFrame where array columns contain full NumPy arrays in each cell. The evaluator returns results in the same rolled format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create rolled input DataFrame: each cell in the 'x' column holds a NumPy array\n",
+    "sites_rolled = pd.DataFrame({\"x\": [np.array([1.0, 2.0, 3.0]), np.array([4.0, -1.0, 0.5])]})\n",
+    "\n",
+    "# Call the evaluator (modifies DataFrame in place)\n",
+    "evaluator(sites_rolled)\n",
+    "\n",
+    "print(\"Rolled results (arrays in DataFrame cells):\")\n",
+    "print(sites_rolled)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "Each cell in the `y` column contains a NumPy array with the squared values. The first row computes `[1, 4, 9]` and the second computes `[16, 1, 0.25]`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "source": [
+    "### Unrolled Invocation via `eval_np`\n",
+    "\n",
+    "With `eval_np`, input and output arrays are unrolled into individual scalar columns. A shape `(3,)` array becomes 3 separate columns in the input and output NumPy arrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Unrolled input: each row has 3 scalar values (x[0], x[1], x[2])\n",
+    "sites_unrolled = np.array([\n",
+    "    [1.0, 2.0, 3.0],\n",
+    "    [4.0, -1.0, 0.5],\n",
+    "])\n",
+    "\n",
+    "# eval_np receives and returns unrolled numpy arrays\n",
+    "results_unrolled = evaluator.eval_np(sites_unrolled)\n",
+    "\n",
+    "print(\"Unrolled input (shape\", sites_unrolled.shape, \"):\")\n",
+    "print(sites_unrolled)\n",
+    "print()\n",
+    "print(\"Unrolled output (shape\", results_unrolled.shape, \"):\")\n",
+    "print(results_unrolled)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "source": [
+    "The unrolled output is a 2D NumPy array where each column corresponds to `y[0]`, `y[1]`, `y[2]`. Both approaches produce the same mathematical result, just in different data representations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "source": [
+    "## OpenMDAO Integration with Array Variables\n",
+    "\n",
+    "Array evaluators integrate seamlessly with OpenMDAO via `EvaluatorOpenMdaoComponent`. Array variables are registered as OpenMDAO inputs/outputs with their full shape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Wrap the array evaluator as an OpenMDAO component\n",
+    "prob = om.Problem()\n",
+    "prob.model.add_subsystem(\n",
+    "    \"comp\", EvaluatorOpenMdaoComponent(evaluator), promotes=[\"*\"]\n",
+    ")\n",
+    "prob.setup()\n",
+    "\n",
+    "# Set array input and run\n",
+    "prob.set_val(\"x\", np.array([2.0, 3.0, 4.0]))\n",
+    "prob.run_model()\n",
+    "\n",
+    "print(f\"Input x = {prob.get_val('x')}\")\n",
+    "print(f\"Output y = x^2 = {prob.get_val('y')}\")\n",
+    "print()\n",
+    "\n",
+    "# Verify shapes are registered correctly\n",
+    "comp = prob.model.comp\n",
+    "input_meta = comp.get_io_metadata(iotypes=\"input\", metadata_keys=[\"shape\"])\n",
+    "output_meta = comp.get_io_metadata(iotypes=\"output\", metadata_keys=[\"shape\"])\n",
+    "for name, meta in input_meta.items():\n",
+    "    print(f\"Input '{meta['prom_name']}': shape = {meta['shape']}\")\n",
+    "for name, meta in output_meta.items():\n",
+    "    print(f\"Output '{meta['prom_name']}': shape = {meta['shape']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a9b0c1",
+   "metadata": {},
+   "source": [
+    "The component correctly computes `y = [4, 9, 16]` for input `x = [2, 3, 4]`. OpenMDAO registers both input and output with shape `(3,)`, matching the `ArrayVariable` definition."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "source": [
+    "## Unrolled Name Generation\n",
+    "\n",
+    "When array variables are unrolled (for `eval_np`, `eval_list`, or internal processing), each element gets a unique name following NumPy indexing syntax:\n",
+    "\n",
+    "### 1-D Arrays\n",
+    "\n",
+    "For a variable named `input` with shape `(3,)`, the unrolled names are:\n",
+    "\n",
+    "- `input[0]`\n",
+    "- `input[1]`\n",
+    "- `input[2]`\n",
+    "\n",
+    "### Multi-dimensional Arrays\n",
+    "\n",
+    "For a variable named `matrix` with shape `(2, 3)`, the unrolled names follow row-major (C-order) iteration:\n",
+    "\n",
+    "- `matrix[0,0]`, `matrix[0,1]`, `matrix[0,2]`\n",
+    "- `matrix[1,0]`, `matrix[1,1]`, `matrix[1,2]`\n",
+    "\n",
+    "The `generate_names` function and the `OptProblem.unroll_names` method produce these names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0c1d2e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate unrolled name generation\n",
+    "from standard_evaluator.problem import generate_names\n",
+    "\n",
+    "# 1-D names\n",
+    "names_1d = generate_names(\"input\", (3,))\n",
+    "print(\"1-D unrolled names:\", names_1d)\n",
+    "\n",
+    "# 2-D names\n",
+    "names_2d = generate_names(\"matrix\", (2, 3))\n",
+    "print(\"2-D unrolled names:\", names_2d)\n",
+    "\n",
+    "# Using OptProblem.unroll_names\n",
+    "print()\n",
+    "print(\"Unrolled variable names from opt_problem:\")\n",
+    "print(opt_problem.unroll_names(opt_problem.variables))\n",
+    "print(\"Unrolled response names from opt_problem:\")\n",
+    "print(opt_problem.unroll_names(opt_problem.responses))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "source": [
+    "The unrolled names use comma-separated indices in brackets, following NumPy's multi-dimensional indexing convention. This naming scheme is used internally when converting between rolled and unrolled representations."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/demos/benchmark_problems.ipynb
+++ b/docs/source/demos/benchmark_problems.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Benchmark Test Problems\n",
+    "\n",
+    "This notebook introduces the benchmark test evaluators available in the Standard Evaluator library. These evaluators implement well-known mathematical optimization problems with known properties, making them ideal for testing optimization algorithms, validating surrogate models, and demonstrating library functionality. You will learn how to browse the catalog of available benchmarks, instantiate and evaluate them, inspect their problem definitions, and access known optimal solutions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## Benchmark Evaluator Catalog\n",
+    "\n",
+    "All benchmark test evaluators are available under `se.evaluators.test`. They are organized into the following categories:\n",
+    "\n",
+    "### Unconstrained Optimization\n",
+    "\n",
+    "| Class Name | Design Variables |\n",
+    "|---|---|\n",
+    "| `CosineTensorProduct` | 1 |\n",
+    "| `ExponentialTensorProduct` | 1 |\n",
+    "| `HyperbolicTangentTensorProduct` | 1 |\n",
+    "| `Sphere` | 1 |\n",
+    "| `Rosenbrock` | 2 |\n",
+    "| `ExtendedRosenbrock` | 2 |\n",
+    "| `Trigonometric` | 2 |\n",
+    "| `HelicalValley` | 3 |\n",
+    "| `HS38` | 4 |\n",
+    "| `PowellSingularFunction` | 4 |\n",
+    "\n",
+    "### Constrained Optimization\n",
+    "\n",
+    "| Class Name | Design Variables | Constraints |\n",
+    "|---|---|---|\n",
+    "| `ConstrainedBetts` | 2 | 1 |\n",
+    "| `WrkBkPrb1` | 2 | 1 |\n",
+    "| `G6Problem` | 2 | 2 |\n",
+    "| `OptlibTest` | 3 | 1 |\n",
+    "| `TP37` | 3 | 2 |\n",
+    "| `CantileveredBeam` | 4 | 3 |\n",
+    "| `CantileveredBeamContinuous` | 4 | 3 |\n",
+    "| `HS47` | 5 | 3 |\n",
+    "| `TwoBarTruss` | 5 | 2 |\n",
+    "| `CantileveredBeamFixedVariable` | 6 | 3 |\n",
+    "| `HS100` | 7 | 4 |\n",
+    "| `SpeedReducer` | 7 | 11 |\n",
+    "| `G7Problem` | 10 | 8 |\n",
+    "| `HS118` | 15 | 17 |\n",
+    "\n",
+    "### Multi-Fidelity\n",
+    "\n",
+    "| Class Name | Design Variables |\n",
+    "|---|---|\n",
+    "| `ForresterMultiFiHi` / `ForresterMultiFiLo` | 1 |\n",
+    "| `ExponentialMultiFiHi` / `ExponentialMultiFiLo` | 2 |\n",
+    "| `SimpleMultiFiHi` / `SimpleMultiFiMid` / `SimpleMultiFiLo` | 2 |\n",
+    "| `BoreholeMultiFiHi` / `BoreholeMultiFiLo` | 8 |\n",
+    "\n",
+    "### Feasibility-Discovery\n",
+    "\n",
+    "| Class Name | Design Variables | Constraints |\n",
+    "|---|---|---|\n",
+    "| `SmallCircleFeasibleRegion` | 2 | 1 |\n",
+    "| `DisconnectedFeasibleRegions` | 2 | 1 |\n",
+    "| `G6Problem` | 2 | 2 |\n",
+    "| `G7Problem` | 10 | 8 |\n",
+    "| `SpeedReducer` | 7 | 11 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "source": [
+    "## Instantiating and Evaluating Benchmarks\n",
+    "\n",
+    "Let's instantiate one evaluator from each of three categories (unconstrained, constrained, and feasibility-discovery) and evaluate each at two sample points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import standard_evaluator as se\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "source": [
+    "### Unconstrained: Rosenbrock (2 variables)\n",
+    "\n",
+    "The Rosenbrock function is a classic non-convex optimization test problem. We evaluate it at two points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rosenbrock = se.evaluators.test.Rosenbrock()\n",
+    "df_rosen = pd.DataFrame({\"x0\": [0.0, 1.0], \"x1\": [0.0, 1.0]})\n",
+    "rosenbrock(df_rosen)\n",
+    "df_rosen"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5b6c7d8",
+   "metadata": {},
+   "source": [
+    "The response column `f` shows the Rosenbrock function value at each point. The global minimum is `f=0` at `(1, 1)`.\n",
+    "\n",
+    "### Constrained: ConstrainedBetts (2 variables, 1 constraint)\n",
+    "\n",
+    "This problem includes both an objective `f` and a constraint `c1`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9f0a1b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "betts = se.evaluators.test.ConstrainedBetts()\n",
+    "df_betts = pd.DataFrame({\"x1\": [2.0, 10.0], \"x2\": [0.0, 5.0]})\n",
+    "betts(df_betts)\n",
+    "df_betts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "source": [
+    "The output DataFrame includes the objective `f` and the constraint `c1`. A feasible solution requires the constraint to satisfy its bounds.\n",
+    "\n",
+    "### Feasibility-Discovery: SmallCircleFeasibleRegion (2 variables, 1 constraint)\n",
+    "\n",
+    "This evaluator has no objective. It defines only a constraint that determines feasibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circle = se.evaluators.test.SmallCircleFeasibleRegion()\n",
+    "df_circle = pd.DataFrame({\"x1\": [0.5, -0.3], \"x2\": [-0.3, -0.3]})\n",
+    "circle(df_circle)\n",
+    "df_circle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "source": [
+    "The constraint `g1` is satisfied (feasible) when `g1 <= 0`. Points inside the small circle centered at `(0.5, -0.3)` with radius `0.15` are feasible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "source": [
+    "## Feasibility-Discovery Benchmarks\n",
+    "\n",
+    "The following five benchmarks are particularly useful for testing algorithms that need to discover feasible regions in the design space:\n",
+    "\n",
+    "### SmallCircleFeasibleRegion\n",
+    "- **Variables:** 2 (`x1`, `x2` in [-1, 1])\n",
+    "- **Constraints:** 1 (`g1 <= 0`)\n",
+    "- **Purpose:** Tests an algorithm's ability to find a small circular feasible region (radius 0.15) in a 2D space. The feasible region occupies a tiny fraction of the design space.\n",
+    "\n",
+    "### DisconnectedFeasibleRegions\n",
+    "- **Variables:** 2 (`x1`, `x2` in [-1, 1])\n",
+    "- **Constraints:** 1 (`g1 <= 0`)\n",
+    "- **Purpose:** Tests an algorithm's ability to discover multiple disconnected circular feasible islands. Algorithms must explore broadly to find all feasible regions rather than converging to a single one.\n",
+    "\n",
+    "### G6Problem\n",
+    "- **Variables:** 2 (`x1` in [13, 100], `x2` in [0, 100])\n",
+    "- **Constraints:** 2 (`g1 <= 0`, `g2 <= 0`)\n",
+    "- **Purpose:** Features a narrow crescent-shaped feasible region defined by the intersection of two nonlinear constraints. Tests an algorithm's ability to navigate tight, curved feasible boundaries.\n",
+    "\n",
+    "### G7Problem\n",
+    "- **Variables:** 10 (`x1` to `x10` in [-10, 10])\n",
+    "- **Constraints:** 8 (`g1` to `g8 <= 0`)\n",
+    "- **Purpose:** A high-dimensional problem with 8 nonlinear inequality constraints. Tests feasibility discovery in a 10D space where the feasible region is defined by many interacting constraints.\n",
+    "\n",
+    "### SpeedReducer\n",
+    "- **Variables:** 7 (`x1` to `x7` with mixed bounds)\n",
+    "- **Constraints:** 11 (`g1` to `g11 <= 0`)\n",
+    "- **Purpose:** A real-world engineering design problem (gear box weight minimization) with 11 constraints on stress, deflection, and geometry. Tests feasibility discovery under many engineering constraints simultaneously."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "source": [
+    "## Accessing the OptProblem Definition\n",
+    "\n",
+    "Each benchmark evaluator has an `opt_problem` property that provides the full optimization problem definition, including variables with bounds, responses, objectives, and constraints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3f4a5b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g6 = se.evaluators.test.G6Problem()\n",
+    "opt = g6.opt_problem\n",
+    "\n",
+    "print(\"Variables:\")\n",
+    "for v in opt.variables:\n",
+    "    print(f\"  {v.name}: bounds={v.bounds}\")\n",
+    "\n",
+    "print(\"\\nResponses:\")\n",
+    "for r in opt.responses:\n",
+    "    print(f\"  {r.name}\")\n",
+    "\n",
+    "print(f\"\\nObjectives: {opt.objectives}\")\n",
+    "print(f\"Constraints: {opt.constraints}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7d8e9f0",
+   "metadata": {},
+   "source": [
+    "The `OptProblem` tells us the G6 problem has 2 design variables with specific bounds, 3 responses (one objective and two constraints), and that we are minimizing `f` subject to `g1 <= 0` and `g2 <= 0`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3e4",
+   "metadata": {},
+   "source": [
+    "## Known Solutions\n",
+    "\n",
+    "Many benchmark evaluators provide a `known_solution` property that returns a DataFrame containing the optimal input values and corresponding response values. This is useful for validating optimization results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"G6Problem known solution:\")\n",
+    "g6.known_solution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1g2",
+   "metadata": {},
+   "source": [
+    "The known solution DataFrame shows the optimal design point and the corresponding objective and constraint values. For the G6 problem, the minimum of `f` is approximately -6961.81 at `x1=14.095`, `x2=0.84296`, with both constraints nearly active (close to zero).\n",
+    "\n",
+    "Not all benchmarks have known solutions. Feasibility-only problems (like `SmallCircleFeasibleRegion`) return `None` since they have no objective to optimize."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/demos/benchmark_problems.ipynb
+++ b/docs/source/demos/benchmark_problems.ipynb
@@ -23,11 +23,11 @@
     "\n",
     "| Class Name | Design Variables |\n",
     "|---|---|\n",
-    "| `CosineTensorProduct` | 1 |\n",
-    "| `ExponentialTensorProduct` | 1 |\n",
-    "| `HyperbolicTangentTensorProduct` | 1 |\n",
-    "| `Sphere` | 1 |\n",
-    "| `Rosenbrock` | 2 |\n",
+    "| `CosineTensorProduct` | User defined |\n",
+    "| `ExponentialTensorProduct` | User defined |\n",
+    "| `HyperbolicTangentTensorProduct` | User defined |\n",
+    "| `Sphere` | User defined |\n",
+    "| `Rosenbrock` | User defined, >=2 |\n",
     "| `ExtendedRosenbrock` | 2 |\n",
     "| `Trigonometric` | 2 |\n",
     "| `HelicalValley` | 3 |\n",
@@ -284,13 +284,13 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.12.0"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/evaluator_hierarchy.ipynb
+++ b/docs/source/demos/evaluator_hierarchy.ipynb
@@ -1,0 +1,301 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f35051af",
+   "metadata": {},
+   "source": [
+    "# Evaluator Hierarchy\n",
+    "\n",
+    "This notebook introduces the core abstraction in the Standard Evaluator library: the **Evaluator** class hierarchy. You will learn how the abstract `Evaluator` base class defines a common API for wrapping analysis codes, explore the available concrete subclasses, and see how decorators add caching and logging capabilities. By the end, you will be able to create evaluators, call them with DataFrames or NumPy arrays, and leverage built-in caching and logging."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "091de718",
+   "metadata": {},
+   "source": [
+    "## The Evaluator Class Hierarchy\n",
+    "\n",
+    "The `Evaluator` abstract base class defines the standard interface that all evaluators share:\n",
+    "\n",
+    "- **`__call__(sites: DataFrame)`** — Evaluate sites provided as a pandas DataFrame. The DataFrame is modified in-place to include response columns.\n",
+    "- **`eval_np(sites: ndarray)`** — Evaluate sites provided as a NumPy array with unrolled scalar columns (excludes fixed variables and unrolls ArrayVariables).\n",
+    "- **`eval_list(sites: List)`** — Same as `eval_np` but accepts and returns Python lists.\n",
+    "\n",
+    "### Concrete Subclasses\n",
+    "\n",
+    "| Class | Purpose |\n",
+    "| ----- | ------- |\n",
+    "| `NumpyEvaluator` | Wraps a user-defined function that operates on NumPy arrays |\n",
+    "| `ExecutableEvaluator` | Wraps an external executable (command-line tool) |\n",
+    "| `ShiftScaleEvaluator` | Applies shift/scale transformations before delegating to another evaluator |\n",
+    "| `OpenMdaoEvaluator` | Wraps an OpenMDAO component as an evaluator |\n",
+    "| `ExcelEvaluator` | Wraps an Excel workbook as an evaluator |\n",
+    "| `MatlabEvaluator` | Wraps a MATLAB function via the MATLAB Engine API |\n",
+    "\n",
+    "### Decorators\n",
+    "\n",
+    "The evaluator constructor supports two decorator parameters:\n",
+    "\n",
+    "- **`cache`** — Pass a path to a SQLite database file to enable caching of evaluated sites. Previously computed sites are looked up rather than re-evaluated.\n",
+    "- **`logging`** — Set to `True` to record every evaluation call. The logged history is accessible via `get_log()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "520c3e2a",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We begin by importing the library using the standard alias convention."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "912206bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import standard_evaluator as se\n",
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d27b6bf4",
+   "metadata": {},
+   "source": [
+    "## Creating and Calling an Evaluator\n",
+    "\n",
+    "We create a `Sphere` benchmark evaluator with 3 design variables. This is a `NumpyEvaluator` subclass representing the sphere function $f(\\mathbf{x}) = \\sum x_i^2$. We then build an input DataFrame with 3 rows and call the evaluator using `__call__`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a97a681",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a Sphere benchmark evaluator with 3 design variables\n",
+    "evaluator = se.evaluators.Sphere(num_independent=3)\n",
+    "\n",
+    "print(\"Inputs:\", evaluator.inputs)\n",
+    "print(\"Outputs:\", evaluator.outputs)\n",
+    "print(\"Variable bounds:\")\n",
+    "for var in evaluator.opt_problem.variables:\n",
+    "    print(f\"  {var.name}: {var.bounds}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43e1dd3b",
+   "metadata": {},
+   "source": [
+    "Now we build an input DataFrame with 3 sample sites and call the evaluator. The `__call__` method modifies the DataFrame in-place, appending the response column `f`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0f08963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build an input DataFrame with 3 rows of sample sites\n",
+    "sites = pd.DataFrame({\n",
+    "    \"x0\": [1.0, 2.0, -3.0],\n",
+    "    \"x1\": [0.5, -1.0, 4.0],\n",
+    "    \"x2\": [2.0, 3.0, -1.0],\n",
+    "})\n",
+    "\n",
+    "# Call the evaluator — modifies sites in-place\n",
+    "evaluator(sites)\n",
+    "\n",
+    "# Display the result with both input and response columns\n",
+    "sites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8da88896",
+   "metadata": {},
+   "source": [
+    "The DataFrame now contains the original input columns (`x0`, `x1`, `x2`) along with the computed response column `f`, where each row's value equals $x_0^2 + x_1^2 + x_2^2$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "535b4b2c",
+   "metadata": {},
+   "source": [
+    "## Using `eval_np` and `eval_list`\n",
+    "\n",
+    "The `eval_np` and `eval_list` methods provide a convenience interface that works with raw NumPy arrays or Python lists instead of DataFrames. Key differences from `__call__`:\n",
+    "\n",
+    "- **Fixed variables are excluded** from the input — you only provide varying design variables.\n",
+    "- **ArrayVariables are unrolled** into individual scalar columns (e.g., a shape `(3,)` array becomes 3 separate values).\n",
+    "- Only the `__call__` method preserves array variables as arrays within DataFrame cells.\n",
+    "\n",
+    "These methods are useful when integrating with optimization libraries that operate on flat numeric arrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1922f5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# eval_np: pass a 2D NumPy array (rows=sites, cols=unrolled inputs)\n",
+    "sites_np = np.array([\n",
+    "    [1.0, 0.5, 2.0],\n",
+    "    [2.0, -1.0, 3.0],\n",
+    "    [-3.0, 4.0, -1.0],\n",
+    "])\n",
+    "\n",
+    "results_np = evaluator.eval_np(sites_np)\n",
+    "print(\"eval_np results (NumPy array):\")\n",
+    "print(results_np)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f7baada",
+   "metadata": {},
+   "source": [
+    "The `eval_list` method works identically but accepts and returns Python lists of lists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9943d29d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# eval_list: pass a list of lists\n",
+    "sites_list = [\n",
+    "    [1.0, 0.5, 2.0],\n",
+    "    [2.0, -1.0, 3.0],\n",
+    "]\n",
+    "\n",
+    "results_list = evaluator.eval_list(sites_list)\n",
+    "print(\"eval_list results (Python lists):\")\n",
+    "print(results_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a167f9ca",
+   "metadata": {},
+   "source": [
+    "Both `eval_np` and `eval_list` return only the response values (here, the `f` column as a single-column array or nested list)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d450346",
+   "metadata": {},
+   "source": [
+    "## Caching Decorator\n",
+    "\n",
+    "By passing a `cache` parameter (a path to a SQLite database file) when constructing an evaluator, the caching decorator is applied. Previously evaluated sites are retrieved from the cache instead of being re-computed. After evaluation, you can inspect the cache using `get_cache()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35f386c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "import os\n",
+    "\n",
+    "# Create a temporary database file for caching\n",
+    "cache_file = os.path.join(tempfile.gettempdir(), \"sphere_cache_demo.db\")\n",
+    "\n",
+    "# Create evaluator with caching enabled\n",
+    "cached_evaluator = se.evaluators.Sphere(num_independent=2, cache=cache_file)\n",
+    "\n",
+    "# Evaluate two sites\n",
+    "sites_cached = pd.DataFrame({\"x0\": [1.0, 2.0], \"x1\": [3.0, 4.0]})\n",
+    "cached_evaluator(sites_cached)\n",
+    "print(\"Evaluation result:\")\n",
+    "print(sites_cached)\n",
+    "\n",
+    "# Inspect the cache\n",
+    "print(\"\\nCached sites:\")\n",
+    "print(cached_evaluator.get_cache())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9e2d37a",
+   "metadata": {},
+   "source": [
+    "The cache stores all evaluated sites. On subsequent calls, any site matching a cached entry (within a configurable tolerance) will retrieve its response from the database rather than re-evaluating."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "632a24fd",
+   "metadata": {},
+   "source": [
+    "## Logging Decorator\n",
+    "\n",
+    "Setting `logging=True` when constructing an evaluator enables the logging decorator. Every evaluation call is recorded, and the full history can be retrieved using `get_log()`. Each logged site includes a `call_num` column indicating which evaluation call it belongs to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7717cb21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create evaluator with logging enabled\n",
+    "logged_evaluator = se.evaluators.Sphere(num_independent=2, logging=True)\n",
+    "\n",
+    "# First evaluation call\n",
+    "sites_a = pd.DataFrame({\"x0\": [1.0, 2.0], \"x1\": [3.0, 4.0]})\n",
+    "logged_evaluator(sites_a)\n",
+    "\n",
+    "# Second evaluation call\n",
+    "sites_b = pd.DataFrame({\"x0\": [5.0], \"x1\": [6.0]})\n",
+    "logged_evaluator(sites_b)\n",
+    "\n",
+    "# Retrieve the full evaluation log\n",
+    "log = logged_evaluator.get_log()\n",
+    "print(\"Evaluation log:\")\n",
+    "log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11ad7249",
+   "metadata": {},
+   "source": [
+    "The log shows all 3 evaluated sites across both calls. The `call_num` column distinguishes which invocation produced each row — sites from the first call have `call_num=1` and the site from the second call has `call_num=2`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/demos/evaluator_interface.ipynb
+++ b/docs/source/demos/evaluator_interface.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Evaluator Interface\n",
+    "\n",
+    "This notebook explains how to define the interface for an evaluator in the Standard Evaluator library. You will learn the two supported approaches: **OptProblem** for optimization problems with objectives and constraints, and **EvaluatorInfo** for general-purpose evaluators that only describe inputs and outputs. By the end, you will know how to create both interface types, pass them to a `NumpyEvaluator`, and access the resulting input/output metadata."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## Two Interface Approaches\n",
+    "\n",
+    "Every evaluator in the Standard Evaluator library requires an interface definition that describes its inputs and outputs. There are two ways to provide this:\n",
+    "\n",
+    "1. **`OptProblem`** — Used when your evaluator represents an optimization problem. It defines typed input variables, response variables, and additionally specifies which responses serve as objectives and which serve as constraints. This is the right choice when you plan to optimize the evaluator.\n",
+    "\n",
+    "2. **`EvaluatorInfo`** — Used for general-purpose evaluators that only need input/output descriptions without optimization semantics. It defines named, typed inputs and outputs but does not include objectives or constraints.\n",
+    "\n",
+    "Both approaches use the same variable types (`FloatVariable`, `IntVariable`, `ArrayVariable`, `CategoricalVariable`) to describe individual inputs and outputs with names, bounds, defaults, and other metadata."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We begin by importing the library using the standard alias convention."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import standard_evaluator as se\n",
+    "from standard_evaluator.evaluators.numpy_evaluator import NumpyEvaluator\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## Creating an OptProblem\n",
+    "\n",
+    "An `OptProblem` defines the full optimization context: input variables with bounds, response variables, objectives to minimize, and constraints to satisfy. Here we create a problem with two float inputs, two responses, one objective, and one constraint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an OptProblem with 2 inputs, 2 responses, 1 objective, 1 constraint\n",
+    "opt_problem = se.OptProblem(\n",
+    "    name=\"demo_problem\",\n",
+    "    variables=[\n",
+    "        se.FloatVariable(name=\"x\", bounds=(-5.0, 5.0)),\n",
+    "        se.FloatVariable(name=\"y\", bounds=(0.0, 10.0)),\n",
+    "    ],\n",
+    "    responses=[\n",
+    "        se.FloatVariable(name=\"f\"),\n",
+    "        se.FloatVariable(name=\"g\"),\n",
+    "    ],\n",
+    "    objectives=[\"f\"],\n",
+    "    constraints=[\"g\"],\n",
+    ")\n",
+    "\n",
+    "print(\"Problem name:\", opt_problem.name)\n",
+    "print(\"Variables:\", opt_problem.variable_names())\n",
+    "print(\"Responses:\", opt_problem.response_names())\n",
+    "print(\"Objectives:\", opt_problem.objectives)\n",
+    "print(\"Constraints:\", opt_problem.constraints)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8b9c0d1",
+   "metadata": {},
+   "source": [
+    "The `OptProblem` validates that all objective and constraint names reference existing responses (or variables for objectives). The bounds on each `FloatVariable` define the feasible design space."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9c0d1e2",
+   "metadata": {},
+   "source": [
+    "## Creating an EvaluatorInfo\n",
+    "\n",
+    "An `EvaluatorInfo` describes inputs and outputs without optimization semantics. It supports the same variable types as `OptProblem` but has no concept of objectives or constraints. Here we create an interface with a `FloatVariable` and an `IntVariable` as inputs, and a `FloatVariable` as output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0d1e2f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an EvaluatorInfo with 2 typed inputs and 1 output\n",
+    "eval_info = se.EvaluatorInfo(\n",
+    "    name=\"weighted_sum\",\n",
+    "    inputs=[\n",
+    "        se.FloatVariable(name=\"a\", bounds=(0.0, 100.0)),\n",
+    "        se.IntVariable(name=\"n\", bounds=(1, 10)),\n",
+    "    ],\n",
+    "    outputs=[\n",
+    "        se.FloatVariable(name=\"result\"),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "print(\"Interface name:\", eval_info.name)\n",
+    "print(\"Inputs:\", eval_info.input_names())\n",
+    "print(\"Outputs:\", [v.name for v in eval_info.outputs])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1e2f3a4",
+   "metadata": {},
+   "source": [
+    "## Instantiating a NumpyEvaluator with EvaluatorInfo\n",
+    "\n",
+    "To create a `NumpyEvaluator`, you subclass it and implement the `eval_np` method. You can pass an `EvaluatorInfo` as the `interface` parameter to define what the evaluator expects as inputs and produces as outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2f3a4b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a NumpyEvaluator that computes result = a * n\n",
+    "class WeightedEvaluator(NumpyEvaluator):\n",
+    "    \"\"\"Computes result = a * n.\"\"\"\n",
+    "\n",
+    "    def eval_np(self, sites, **kwargs):\n",
+    "        a = sites[:, 0]\n",
+    "        n = sites[:, 1]\n",
+    "        return (a * n).reshape(-1, 1)\n",
+    "\n",
+    "\n",
+    "# Instantiate using the interface parameter\n",
+    "weighted_eval = WeightedEvaluator(interface=eval_info)\n",
+    "\n",
+    "print(\"Evaluator inputs:\", weighted_eval.inputs)\n",
+    "print(\"Evaluator outputs:\", weighted_eval.outputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3a4b5c6",
+   "metadata": {},
+   "source": [
+    "The evaluator now knows it expects columns `a` and `n` as inputs and produces a column `result` as output. Internally, the `EvaluatorInfo` is converted to an `OptProblem` (without objectives or constraints) so that both interface types share the same underlying data model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4b5c6d7",
+   "metadata": {},
+   "source": [
+    "## Instantiating a NumpyEvaluator with OptProblem\n",
+    "\n",
+    "When you have an optimization problem definition, pass it directly as the `opt_problem` parameter. This gives the evaluator access to objective and constraint metadata in addition to the variable definitions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5c6d7e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a NumpyEvaluator that computes f = x^2 + y^2, g = x + y\n",
+    "class OptEvaluator(NumpyEvaluator):\n",
+    "    \"\"\"Computes f = x^2 + y^2 and g = x + y.\"\"\"\n",
+    "\n",
+    "    def eval_np(self, sites, **kwargs):\n",
+    "        x = sites[:, 0]\n",
+    "        y = sites[:, 1]\n",
+    "        f = x**2 + y**2\n",
+    "        g = x + y\n",
+    "        return np.column_stack([f, g])\n",
+    "\n",
+    "\n",
+    "# Instantiate using the opt_problem parameter\n",
+    "opt_eval = OptEvaluator(opt_problem=opt_problem)\n",
+    "\n",
+    "# Call the evaluator with a DataFrame\n",
+    "sites = pd.DataFrame({\"x\": [1.0, -2.0, 3.0], \"y\": [2.0, 5.0, 1.0]})\n",
+    "opt_eval(sites)\n",
+    "\n",
+    "print(\"Inputs property:\", opt_eval.inputs)\n",
+    "print(\"Outputs property:\", opt_eval.outputs)\n",
+    "print(\"\\nEvaluation results:\")\n",
+    "sites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6d7e8f9",
+   "metadata": {},
+   "source": [
+    "The `inputs` property returns the list of input variable names (`['x', 'y']`) and the `outputs` property returns the list of response names (`['f', 'g']`). The DataFrame is modified in-place with the computed response columns appended."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7e8f9a0",
+   "metadata": {},
+   "source": [
+    "## When to Use OptProblem vs EvaluatorInfo\n",
+    "\n",
+    "Choose the interface type based on your use case:\n",
+    "\n",
+    "| Use Case | Interface Type | Reason |\n",
+    "| -------- | -------------- | ------ |\n",
+    "| Running optimization with an optimizer | `OptProblem` | Defines objectives and constraints needed by optimization algorithms |\n",
+    "| Wrapping analysis code for general evaluation | `EvaluatorInfo` | Only input/output descriptions are needed, no optimization semantics |\n",
+    "| Integration with `EvaluatorOpenMdaoComponent` | `OptProblem` | The OpenMDAO component uses objectives and constraints for driver setup |\n",
+    "| Building surrogate models | Either | Surrogate training only needs input/output structure |\n",
+    "\n",
+    "**Summary:**\n",
+    "- Use **`OptProblem`** when your evaluator will be used in an optimization context and you need to specify which responses are objectives to minimize and which are constraints to satisfy.\n",
+    "- Use **`EvaluatorInfo`** when you only need to describe the evaluator's inputs and outputs without optimization semantics — for example, when wrapping a general-purpose analysis tool or building a data pipeline."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/demos/index.rst
+++ b/docs/source/demos/index.rst
@@ -11,4 +11,10 @@ The documents in this section show demos of the standard evaluator.
    group_creation_NASA
    group_manipulation
    group_reading
+   evaluator_hierarchy
+   surrogate_models
+   openmdao_component
+   array_variables
+   benchmark_problems
+   evaluator_interface
    

--- a/docs/source/demos/openmdao_component.ipynb
+++ b/docs/source/demos/openmdao_component.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# OpenMDAO Component Integration\n",
+    "\n",
+    "This notebook demonstrates how to wrap any Standard Evaluator as an OpenMDAO `ExplicitComponent` using `EvaluatorOpenMdaoComponent`. You will learn how OptProblem variables map to OpenMDAO inputs, how responses map to outputs (with bounds and scaling), and how to serialize an evaluator for later reconstruction inside an OpenMDAO model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## How EvaluatorOpenMdaoComponent Works\n",
+    "\n",
+    "The `EvaluatorOpenMdaoComponent` class bridges the Standard Evaluator API and OpenMDAO:\n",
+    "\n",
+    "- **Variables → Inputs**: Each variable in the evaluator's `OptProblem` becomes an OpenMDAO input. The variable's `default` value sets the input default, and `bounds` define the feasible range.\n",
+    "- **Responses → Outputs**: Each response becomes an OpenMDAO output. Response `bounds` map to `lower`/`upper`, and `shift`/`scale` map to OpenMDAO's `ref0`/`ref` scaling parameters.\n",
+    "- **Compute**: When OpenMDAO calls `compute()`, the component builds a pandas DataFrame from the current inputs, calls the evaluator, and extracts the response values back into the OpenMDAO output vector.\n",
+    "\n",
+    "This means any evaluator — whether backed by a NumPy function, a surrogate model, or an external executable — can participate in an OpenMDAO model with a single line of wrapping code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We start by importing the Standard Evaluator library and OpenMDAO."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import standard_evaluator as se\n",
+    "from standard_evaluator.evaluators.numpy_evaluator import NumpyEvaluator\n",
+    "from standard_evaluator.components import EvaluatorOpenMdaoComponent\n",
+    "import openmdao.api as om\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## Wrapping an Evaluator as an OpenMDAO Component\n",
+    "\n",
+    "We define a simple evaluator that computes $f(x, y) = x^2 + y^2$. First we create an `OptProblem` with two variables and one response, then implement the `NumpyEvaluator` subclass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the optimization problem interface\n",
+    "opt_problem = se.utilities.create_opt_problem(num_independent=2, num_dependent=1)\n",
+    "opt_problem.variables[0].name = \"x\"\n",
+    "opt_problem.variables[0].bounds = (-5.0, 5.0)\n",
+    "opt_problem.variables[0].default = 1.0\n",
+    "opt_problem.variables[1].name = \"y\"\n",
+    "opt_problem.variables[1].bounds = (-5.0, 5.0)\n",
+    "opt_problem.variables[1].default = 2.0\n",
+    "opt_problem.responses[0].name = \"f\"\n",
+    "opt_problem.responses[0].bounds = (0.0, 50.0)\n",
+    "opt_problem.responses[0].scale = 0.02\n",
+    "opt_problem.responses[0].shift = -25.0\n",
+    "opt_problem.objectives = [\"f\"]\n",
+    "opt_problem.constraints = []\n",
+    "\n",
+    "\n",
+    "# Implement the evaluator\n",
+    "class SumOfSquares(NumpyEvaluator):\n",
+    "    \"\"\"Computes f = x^2 + y^2.\"\"\"\n",
+    "\n",
+    "    def eval_np(self, sites, **kwargs):\n",
+    "        x = sites[:, 0]\n",
+    "        y = sites[:, 1]\n",
+    "        return (x**2 + y**2).reshape(-1, 1)\n",
+    "\n",
+    "\n",
+    "evaluator = SumOfSquares(opt_problem=opt_problem)\n",
+    "print(\"Inputs:\", evaluator.inputs)\n",
+    "print(\"Outputs:\", evaluator.outputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "source": [
+    "Now we wrap the evaluator in an `EvaluatorOpenMdaoComponent`, add it to an OpenMDAO Problem, and run the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an OpenMDAO Problem with the wrapped evaluator\n",
+    "prob = om.Problem()\n",
+    "prob.model.add_subsystem(\n",
+    "    \"comp\", EvaluatorOpenMdaoComponent(evaluator), promotes=[\"*\"]\n",
+    ")\n",
+    "prob.setup()\n",
+    "\n",
+    "# Set input values and run\n",
+    "prob.set_val(\"x\", 3.0)\n",
+    "prob.set_val(\"y\", 4.0)\n",
+    "prob.run_model()\n",
+    "\n",
+    "print(f\"x = {prob.get_val('x')[0]}\")\n",
+    "print(f\"y = {prob.get_val('y')[0]}\")\n",
+    "print(f\"f = x^2 + y^2 = {prob.get_val('f')[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "source": [
+    "The component correctly computes $f = 3^2 + 4^2 = 25$. The evaluator's `OptProblem` defined the variable names and bounds, and the component automatically registered them as OpenMDAO inputs and outputs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "## Inspecting OpenMDAO Input and Output Metadata\n",
+    "\n",
+    "The component maps `OptProblem` variable/response properties to OpenMDAO metadata. We can retrieve this metadata to verify how bounds, defaults, and scaling are configured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comp = prob.model.comp\n",
+    "\n",
+    "# Input metadata: default values and shape\n",
+    "input_meta = comp.get_io_metadata(\n",
+    "    iotypes=\"input\", metadata_keys=[\"val\", \"shape\", \"units\"]\n",
+    ")\n",
+    "print(\"Input metadata:\")\n",
+    "print(\"-\" * 50)\n",
+    "for abs_name, meta in input_meta.items():\n",
+    "    print(f\"  {meta['prom_name']:>4s}: default = {meta['val']}, shape = {meta['shape']}\")\n",
+    "\n",
+    "print()\n",
+    "\n",
+    "# Output metadata: bounds and scaling\n",
+    "output_meta = comp.get_io_metadata(\n",
+    "    iotypes=\"output\", metadata_keys=[\"val\", \"shape\", \"lower\", \"upper\", \"ref0\", \"ref\"]\n",
+    ")\n",
+    "print(\"Output metadata:\")\n",
+    "print(\"-\" * 50)\n",
+    "for abs_name, meta in output_meta.items():\n",
+    "    print(f\"  {meta['prom_name']:>4s}: lower = {meta['lower']}, upper = {meta['upper']}\")\n",
+    "    print(f\"        ref0 = {meta['ref0']}, ref = {meta['ref']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "The metadata shows:\n",
+    "\n",
+    "- **Inputs** receive their `default` values from the OptProblem variables (x defaults to 1.0, y to 2.0).\n",
+    "- **Outputs** receive `lower`/`upper` bounds from the response bounds (0.0 to 50.0), and `ref0`/`ref` are computed from the response's `shift` and `scale` parameters. OpenMDAO uses `ref0` and `ref` to normalize the output for optimizers: `normalized = (physical - ref0) / (ref - ref0)`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "source": [
+    "## Serialization and Reconstruction via evaluator_options\n",
+    "\n",
+    "Surrogate models (which inherit from `NumpyEvaluator`) support serialization via `to_dict()`. The resulting dictionary can be passed as the `evaluator_options` keyword argument to construct a new `EvaluatorOpenMdaoComponent` — without needing the original Python class definition. This is useful for saving trained models and loading them into OpenMDAO workflows later.\n",
+    "\n",
+    "We demonstrate this by training a `PolynomialModel` on data from our evaluator, wrapping it in a component, then reconstructing an equivalent component from the serialized dictionary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from standard_evaluator.surrogate_models import PolynomialModel, PolynomialModelOptions\n",
+    "\n",
+    "# Generate training data from the evaluator\n",
+    "np.random.seed(42)\n",
+    "train_df = pd.DataFrame({\n",
+    "    \"x\": np.random.uniform(-5, 5, 20),\n",
+    "    \"y\": np.random.uniform(-5, 5, 20),\n",
+    "})\n",
+    "evaluator(train_df)\n",
+    "\n",
+    "# Train a degree-2 polynomial model (exact fit for x^2 + y^2)\n",
+    "poly_model = PolynomialModel(\n",
+    "    sites=train_df,\n",
+    "    options=PolynomialModelOptions(degree=2),\n",
+    "    opt_problem=opt_problem,\n",
+    ")\n",
+    "\n",
+    "# Serialize the trained model\n",
+    "model_dict = poly_model.to_dict()\n",
+    "print(f\"Serialized model type: {model_dict['type']}\")\n",
+    "print(f\"Dictionary keys: {list(model_dict.keys())}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "source": [
+    "Now we use the original polynomial model in an OpenMDAO component and compare its output to a reconstructed component built from the serialized dictionary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Original component using the trained polynomial model\n",
+    "prob_original = om.Problem()\n",
+    "prob_original.model.add_subsystem(\n",
+    "    \"comp\", EvaluatorOpenMdaoComponent(poly_model), promotes=[\"*\"]\n",
+    ")\n",
+    "prob_original.setup()\n",
+    "prob_original.set_val(\"x\", 3.0)\n",
+    "prob_original.set_val(\"y\", 4.0)\n",
+    "prob_original.run_model()\n",
+    "original_f = prob_original.get_val(\"f\")[0]\n",
+    "print(f\"Original component output:      f = {original_f:.6f}\")\n",
+    "\n",
+    "# Reconstructed component from evaluator_options\n",
+    "prob_reconstructed = om.Problem()\n",
+    "prob_reconstructed.model.add_subsystem(\n",
+    "    \"comp\", EvaluatorOpenMdaoComponent(evaluator_options=model_dict), promotes=[\"*\"]\n",
+    ")\n",
+    "prob_reconstructed.setup()\n",
+    "prob_reconstructed.set_val(\"x\", 3.0)\n",
+    "prob_reconstructed.set_val(\"y\", 4.0)\n",
+    "prob_reconstructed.run_model()\n",
+    "reconstructed_f = prob_reconstructed.get_val(\"f\")[0]\n",
+    "print(f\"Reconstructed component output: f = {reconstructed_f:.6f}\")\n",
+    "\n",
+    "print(f\"\\nOutputs match: {np.isclose(original_f, reconstructed_f)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "source": [
+    "The reconstructed component produces identical output. The `evaluator_options` keyword internally calls `SurrogateModel.from_dict()` to rebuild the trained model, so the full prediction capability is preserved without needing the original training data or class definition in scope."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/demos/replace.html
+++ b/docs/source/demos/replace.html
@@ -2955,7 +2955,7 @@ return _;
 
 </head>
 <body>
-<div id="all-diagram-content" class="non-embedded-diagram" data-openmdao-version='3.37.0'>
+<div id="all-diagram-content" class="non-embedded-diagram" data-openmdao-version='3.43.0'>
     <div id="diagram-content">
         <!-- Toolbar -->
         <div id="toolbarLoc">
@@ -3255,7 +3255,7 @@ return _;
 </div>
 
 <script type="text/javascript">
-    var compressedModel = "eJztW21v2zYQ/iuGPiWd68lyHDsBNqBoM6BAkQEbui9BIFAUbbORJYWU3dhB/vuOlCiRMpU6bd0Ylj8ksO6OL/dC3nMU9ehkjBDnsvPoxGgufjgsSTKn23GyVWo84whxLgi+P0c09v3Lj3FG2JyEFGVkIETIQ8oI5zSJhWC8iCIgxkkc0Zgg5vMkWhImurj+dNn55/P139fvrxyLiJ+kWdHJo0NTRuMMfvafQHSjq0/XRlfb9ANioAqZBxHxvyAMpAmKOAHyghMf0eyOxBoxJ/hz0HmCcJaIYd1eX+Ogh4rT7w0rDo1pRlGkc12hBU7maRKTOPMLKxe24ouAr3hG5oruTFmySIVilPspYiiKSKTNDc9oFDI53ZvKhT5aZIlPl1j3Y9m34cwkJfE8REkPJ4z0aBySdImYmN+l/w56+Sgo/yH2HigvcvE3/Fq0tDb7RptNI5XmfMZQdYs7Ulen0YZLVzdessjShew+VKQ4RIyhVTFkSDlmJCPakEDKGA0WGQk1Kp+hvP1Jv3sqOyQcK83pPI0oppkekhBC0lPXMH0hs0RCrxuIpNv8SUYmaEMxEYI3Oj0POfUMcWqVQw9laGoG6LfdAF7bDTBouwHO2m6AYdsNcN52A4zaboBx2w1w0UIDCIpePISE0SX35ySbJUKJAoraNWOL2BdVkw/wd6XRUfQVrbgAtLpaUHJ8kYpmbCEIyu6frz9c/fXx+upDpWuugTJcMQdll+IR0LlfIxWGVZA7+SqhtmqepvojI5NyIPjtOqLWcYt+c2YhmaGpGuPJCBjA5wZ0tBceZRX5byF+LB73o3hcb+E8rWos5sJ75IFgXxaOV/DLXi/eOKvOHx3U+a0TwB+Gv9C5bXDz3heQQuHm+hHpVqTxr9g0Xy1FBC3SFbdI17BFuq72G+Wcbav/2Zb6n22Pcn4Mz8yQMBeaik1V5DNu0VZtzCaykY9+sIKsEus5NUyAEiWQkaeKaiKQtXFy87NT2PKYwg5v+R9T2KvoupNtra0pbLnfKWy0rf6jLfUfHVgKq+ui6sxQFJrVRs9x7gSrovLNX8JCmUksqRERlrygOH9XiB+L8/0ozqckAY+z1bdd+P34ZspoCBDn5B6wzbrzJjp9A835iefKxR9ECJiwuxB2oujdjvp1eqhYKGpRHrlvka7rFukKS3fXCMGDmRUbxXeihBup3U7/gZWOoxxHOY5yHOU4ynGU4yivP0oT8Ol2tsY+uqgV/oi65hfgnx8BP57Qbqf/tkOYXqOVTRN7h3ICI4YxD0rwxAiWn11khwxNRZFN4xgKaRGaWhENhTfrvOncnf7ed133UEvq+nrcQfVlW46HtPb0gL3bn0p2Jye9uq5sf3Tt7/wlPOwU+3awr+nv9tyz0XYWkKJb2UBKHkZm2fHZ/u7eGTjzcOiDdWaig5HXH6PJaHg+nly4HsZj4roEX3gDfD4JBkReE4eMAUbMZiJwuR9ByAnP3srMAFkOy0mW9EeHMxls5cdKveKTm6ngyxcVPUjCPebI5bAp3a9Lq8PxXtTUxGtsct/UZNDYZN3U5ExrIi5D9tb9HmoSHlqEgybhc4swbhIeWYTD7YW9ZuGxRbhRwQuLsKmgadYSFtTiQNL1ZkqnlWUAbJH0ektbv3eOXEQo4F7KkrlcRXlKkevJGH5jPl2jI8W+M+ispLOSroWqYkabzPuSeb/JXJdMeYZdBdplcXOjiiZlgvnKRxFFXOdiM5a6eqwoTliRvSYyMoOhqzvb8HxX95LiSH+p1GbYXaY/panKhaYlxLn2RhgVh92W2GqMuCqg6tFVBZDiyFAyti7DycY2ZXjY2I0M9xqbjuFbY29R7jX2EJuHjX2j7mRj6RsONdZ53afGujYXtHBgCPlFZpEKvnzISTqAgXQ1p2sk8oGzkeKDBaTi4n2uTB40BlxAQx/AyRJKloDM0JLKV67OV8TiPHDSzOckyyDllnfSczxDp7EPzfLea3aEKAvzpDfI77hzjCJSvQQ27kGpe/JjKaku0b/N0bpxMb64Nm+/no8RnhG/Kr8W0goVeMiSDFBQbSI5sTbZCj0VXU8ilGmYSvWoKjVfZv8cmmgghq6FjmIUQCxipd0oVCDrTp4sGCa2BGfHlNMoCYQCRbdPm4FaWV1NQSmrrhVo3xEYAa1cMHRNHwzd3TpBffBgeKEg7toLphEaPTLc3iNP0jocSnVOuHWvNW+LVJuunEKz5nZ71ak1+1mN+owny00k+OK83LHPe6HZdURuR7Iuqsxvmq3R/ppvLYtDzyzmJzR5iqkZXcV8HvFqQfTzR3K/yOsX4+RHm8rrugzn2/1ruswAgt/vrhwi1NylsEKDx94OvN7A05029i6ObnuB2wr7vthtORLAEXReFvllGVr13fmzU2Fo3dUaI2hi4CaGgZGXJaMGkXVG0MTATYyqDDEgLUjUa43t5CzFhlVubZQ58kS7ELHWR3WBu2e5zKkdbTw9/Q8TzPt/";
+    var compressedModel = "eJztXF9v2zYQ/yqGnpLO9WzHrpMAG1C0GVBgyIAN3UsQEBRF20xkSSElJ3aQ774jRUqkLKVOVzdG5IcG1vH45353x7sjpT56KafUO+88ehFeyB8ej+PU63a8dJU4zyTEQkgCQgvMIoTOv0Qp5QsaMJzSE8lCHxJOhWBxJBmjLAyBGMVRyCKKORJxuKRcDnH553nn76+Xf11+uvBqWFCcpHqQR48lnEUp/BwAZ0D9bIYMZYpDQZ+AvDHBn5fOBFuODgLShR9SdIOJGR7ImaAIs/SWRhYxJ6AFIDHFJI3ltP3ewGrBD2XLoDcuW1jEUoZDu7UvpSDxIokjGqVIY68RFJkvViKlC0P3ZjzOEikYEyjBHIchDa21kTkLA66We1UqFuEsjRFbElu7xdiOiuOERosAxz0Sc9pjUUCTJeZyfefoI4zyRVL+xfwTUF6k+G9oW/es7faNPpsgFXA+A1QVcU/J6jViuOzb4MVZmmRq+MCQogBzjld6yoAJwmlKrSmBlHLmZykNLKqY47z/0aB7rAakghjJ2SIJGWGpbZJgQkpTl7B8ybPEUq4rsKTr/ElZJkjDCJWMVzY9NznzDHZay4cfCtO0ABi0HYBh2wE4aTsAo7YDMG47AB/aDsCk7QCcth2AsxYCICl28RBQzpYCLWg6j6UQOhWtl4xnEZK1FIL0d2XRcXiPV0ImtLZYUHLcKEFTnim06BRnYYoMPlcDuRijja+Xny/++HJ58blEIJfLsOuVGbT0I+TsqELScJtEPL5XCbjpniT2I6fTYiL43fdkBdTX4+aNmjPFMzPHk2NGkLU7CWV9OVJUnP9o9kOhuc+F5noLlVoVpl6L6NEHSpAqMi/gV31teeWtOr91cOeXjg//CPwLvOsG5e99sSkFbq41sY0ii37GBvtq4cRvkaykRbIGLZJ1td8Z0Whb+Udbyj/aPiPaRe4zxxJEPJNbrYxyogYDs127WZB6RP4KYk1kR9ogBkoYQ5yeFTHf0fDaOfv50YFteQhsb29TOAS2V5F1J5tdWwPbcr8D22Rb+Sdbyj9pRWCrSmhq0kAWpZXCsEF6daEY80CFl5p4iSmPX1Ddf9Tsh+p+n6v7GY3BDvjq24r9/lRoxlkA2dDRHaRB68678PgddBdHw77aJ/wQQyNsRJQfGXq3Y34dv9W0KWxRyLlrkazrFskKrrvrZGIIK9MbxXcmFFdKup3+AZQOsxxmOcxymOUwy2GWwyyvP0tT4tPtbJ372Ky16Y+sa35C/vN/kp+hlG6nf7bLMIeNKLsQD9/2YY2c3D1UIVPHhH506R1wPJOlN4siKK+lwVqlNZTjvPOuc3v866Df77/VQrvqpTuoyeqc9C15pG2wt/tT3+7kqNiWle+PrIOd3+3DTrFvNwOW/P1efzTZDgHFuhUGivMtx5vdXg7s7M7BWwRjBNjMpRVMg5P+hA6C0eTsdOKfkWAwGo/OBuOzCcRO4qu9HaIIQJjOpTELFIIZSoivVbSAyEfUGgv6oye4MsDiG6qe/hJoluogPOitBz3sKQ/ZZB5YzPJWpGdO0XthU5dhY5e7pi4n1S4gb483cY8aJ1g3dRnXyBxszzxsZv5QM7LfxDypYSZNzKc1y2jU01kNs7sMF6kiVaiAruh2N7PMVc0EpIZz2FvWjXvrKR/CvhgmPF4oJ8rDjHInZ/qN9XSdgUzzrUPnBZ0XdMtWTWO42XhXNN5tNq6LRnXaXfrLuX4dpNS5gWCxQjhkWNitxNV417ZC0xKU5GETGbvG0LWV7Wi+a2vJtCh9mXAncXd2BSOR4/0Obo6TO6A5vuwowvFbB0vH4xxpHfeqg9VxqSqyjgtV4XJcpopYYUwqQzCLNemCaxjyQmDDq/QtQY2rNTpg6V9VZyv9ybQsPRUyAogvKoqUKc3nnGQnNRCtFmyNZTzwNsK+fYusggeLIFdgAYKEZQlljE/neMnU5ax3j3mUG04CQZ2mKQRcp7JJkpin+cjOrJKQ5zQmZMNTlqcnea6g6Nd61SoRUsuvJoru2/uVd/vJnJJbpFZfEmW24VMayfWWmQnUV/E9imS6aX3eQAlEZQzBvGSEXmiaRUSLUQR2qDgJtohPCjl6l8HsqUpQICvEAKtoifAtFl0X/K0VXNYGcrtgM9g6eFuET+9jJFgAiX/7FL+Aqo4lIUWxfyMLjSVti+SgZDqjXJs7qti7HvAtCj7jOGC0PSaOlVnridogsGDSq3FE40wgdXKB2+TYaZziUJ3hiAScGjKZlghunV+2bFfLS6iKyJVC+NHDQX5Qd5J/GCwIDmn5iqvzQYiR9VRxGlHf57cOztfE+lvj+m+aCQZYUHmNlOlFG6FzU60sJCdWFlueAuuhpyFOrbNhM6K5ccr9Pj9MLTsJtpYyyllizmQ5fGVOMtX9mYgzThQK1bPF+rPxWRj7UgA9rNRCpc4vUTdLMMKaV6mtj6+d8wCjgnHf1cG4v1slmK/EHS1o4q614ILQqJEP22vkSaEjEkhsdQCoHoi4b8iXJyNqCc2S1+NVpVbwqwX1GU0WBx/+jfdyxT6vhWbVUXWEova8En4Xtkb8Ld3WOId9/OP+vwP5CWsFdGPzucUbhxjkj6pM37jBtpbyuioj+RHVa6rMObz+fnXl53gVdZkDvQaNvT8Z9k6GttJOh2cHtb1AbRrfF6stzwRICIMX15LF1ZnrxZ3fO813ElWG22dba+4n1GcjmsW6tNiOr+bWopbPucBYQXN5mdHQ4Dc1kKYG57JiWTRU7irsBr+pgTQ15J8XW+fZT0//AWHobws=";
     var initialPath = "null";
 </script>
 
@@ -13286,6 +13286,7 @@ class OmStyle extends Style {
         ['LN: USER',        null,              '#fccde5'],
         [null,              'NL: Newton',      '#d9d9d9'],
         [null,              'NL: BROYDEN',     '#bc80bd'],
+        ['LN: PETScDirect', null,              '#636b2f'],
         ['solve_linear',    'solve_nonlinear', '#ccebc5'],
         ['other',           'other',           '#ffed6f'],
     ];
@@ -13676,11 +13677,13 @@ class OmLegend extends Legend {
             { 'name': "Collapsed", 'color': OmStyle.color.collapsed },
             { 'name': "Declared Partial", 'color': OmStyle.color.declaredPartial }
         ];
-                
+
         const rootLinearSolver =
-            OmStyle.solverStyleObject.find(x => x.ln === modelData.tree.linear_solver);
+            OmStyle.solverStyleObject.find(x => x.ln === modelData.tree.linear_solver)
+            || OmStyle.solverStyleObject.find(x => x.ln === "other");
         const rootNonLinearSolver =
-            OmStyle.solverStyleObject.find(x => x.nl === modelData.tree.nonlinear_solver);
+            OmStyle.solverStyleObject.find(x => x.nl === modelData.tree.nonlinear_solver)
+            || OmStyle.solverStyleObject.find(x => x.nl === "other");
         this.linearSolvers = [
             { 'name': modelData.tree.linear_solver, 'color': rootLinearSolver.color }
         ];

--- a/docs/source/demos/surrogate_models.ipynb
+++ b/docs/source/demos/surrogate_models.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Surrogate Models\n",
+    "\n",
+    "This notebook demonstrates how to train, evaluate, and serialize surrogate models using the Standard Evaluator library. Surrogate models are fast mathematical approximations of expensive evaluators, enabling rapid prediction of response values without re-running the underlying analysis. You will learn how to use the `PolynomialModel`, SMT-based models (such as RBF), serialize and reconstruct trained models, and configure model options."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "The SMT-based surrogate models require the optional `smt` dependency. Install it with:\n",
+    "\n",
+    "```bash\n",
+    "pip install standard-evaluator[smt]\n",
+    "```\n",
+    "\n",
+    "The `PolynomialModel` is available with the base installation and does not require any extra dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import standard_evaluator as se"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Hierarchy\n",
+    "\n",
+    "The surrogate model classes follow this inheritance hierarchy:\n",
+    "\n",
+    "- **`SurrogateModel`** (base class, inherits from `NumpyEvaluator`)\n",
+    "  - **`PolynomialModel`** — Polynomial response surface model (base dependencies only)\n",
+    "  - **`AbstractSmtModel`** — Base class for all SMT-based models (requires `smt`)\n",
+    "    - **`RadialBasisFunctionModel`** (RBF) — Radial basis function interpolation\n",
+    "    - **`InverseDistanceWeightingModel`** (IDW) — Inverse distance weighting interpolation\n",
+    "    - **`GradientEnhancedNeuralNetworksModel`** (GENN) — Gradient-enhanced neural network\n",
+    "    - **`LeastSquaresApproximationModel`** (LS) — Least-squares polynomial approximation\n",
+    "    - **`RegularizedMinimalEnergyTensorProductBSplines`** (RMTS) — Regularized tensor-product B-splines\n",
+    "    - **`SecondOrderPolynomialApproximationModel`** (SOPA) — Second-order polynomial approximation\n",
+    "\n",
+    "All surrogate models share a common API:\n",
+    "- **Training**: Pass a `pd.DataFrame` of sites (inputs + true responses) to the constructor\n",
+    "- **Prediction**: Call the model with a DataFrame of new input sites (modifies in-place)\n",
+    "- **Serialization**: Use `to_dict()` and `from_dict()` for round-trip persistence\n",
+    "- **Options**: Configure model behavior via a Pydantic options model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training a PolynomialModel\n",
+    "\n",
+    "We start by training a `PolynomialModel` on sample data from the Sphere test evaluator. First we generate training sites by sampling within the variable bounds, then we evaluate the true responses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a test evaluator (Sphere function: f = x0^2 + x1^2)\n",
+    "evaluator = se.evaluators.test.Sphere(num_independent=2, num_dependent=1)\n",
+    "\n",
+    "# Get variable bounds from the opt_problem\n",
+    "opt_problem = evaluator.opt_problem\n",
+    "variables = opt_problem.variables\n",
+    "\n",
+    "# Generate 20 random training sites within bounds\n",
+    "np.random.seed(42)\n",
+    "n_train = 20\n",
+    "train_data = {}\n",
+    "for var in variables:\n",
+    "    lb, ub = var.bounds\n",
+    "    train_data[var.name] = np.random.uniform(lb, ub, n_train)\n",
+    "\n",
+    "train_sites = pd.DataFrame(train_data)\n",
+    "\n",
+    "# Evaluate true responses at training sites\n",
+    "evaluator(train_sites)\n",
+    "print(f\"Training sites shape: {train_sites.shape}\")\n",
+    "train_sites.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we train a degree-2 polynomial model on these sites and predict at new test points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from standard_evaluator.surrogate_models import PolynomialModel, PolynomialModelOptions\n",
+    "\n",
+    "# Train the polynomial model (degree 2 fits a quadratic — perfect for Sphere)\n",
+    "poly_model = PolynomialModel(\n",
+    "    sites=train_sites,\n",
+    "    options=PolynomialModelOptions(degree=2),\n",
+    "    opt_problem=opt_problem,\n",
+    ")\n",
+    "\n",
+    "# Generate 5 new test sites for prediction\n",
+    "n_test = 5\n",
+    "test_data = {}\n",
+    "for var in variables:\n",
+    "    lb, ub = var.bounds\n",
+    "    test_data[var.name] = np.random.uniform(lb, ub, n_test)\n",
+    "\n",
+    "test_sites = pd.DataFrame(test_data)\n",
+    "\n",
+    "# Predict using the polynomial model (modifies DataFrame in place)\n",
+    "poly_model(test_sites)\n",
+    "predicted = test_sites[\"f\"].values.copy()\n",
+    "\n",
+    "# Compute true values for comparison\n",
+    "true_sites = test_sites[evaluator.inputs].copy()\n",
+    "evaluator(true_sites)\n",
+    "true_values = true_sites[\"f\"].values\n",
+    "\n",
+    "# Display predicted vs true\n",
+    "comparison = pd.DataFrame({\n",
+    "    \"x0\": test_sites[\"x0\"],\n",
+    "    \"x1\": test_sites[\"x1\"],\n",
+    "    \"Predicted\": predicted,\n",
+    "    \"True\": true_values,\n",
+    "    \"Error\": np.abs(predicted - true_values),\n",
+    "})\n",
+    "print(\"Polynomial Model Predictions vs True Values:\")\n",
+    "comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The degree-2 polynomial model fits the Sphere function exactly (since the Sphere function is itself a degree-2 polynomial), resulting in near-zero prediction errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Serialization and Reconstruction\n",
+    "\n",
+    "Surrogate models can be serialized to a dictionary using `to_dict()` and reconstructed using `SurrogateModel.from_dict()`. This enables saving trained models to disk and loading them later without retraining."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from standard_evaluator.surrogate_models import SurrogateModel\n",
+    "\n",
+    "# Serialize the trained model\n",
+    "model_dict = poly_model.to_dict()\n",
+    "print(f\"Serialized model type: {model_dict['type']}\")\n",
+    "print(f\"Dictionary keys: {list(model_dict.keys())}\")\n",
+    "\n",
+    "# Reconstruct from dictionary\n",
+    "reconstructed_model = SurrogateModel.from_dict(model_dict)\n",
+    "\n",
+    "# Verify predictions match\n",
+    "verify_sites = pd.DataFrame(test_data)  # fresh copy of test inputs\n",
+    "reconstructed_model(verify_sites)\n",
+    "reconstructed_predictions = verify_sites[\"f\"].values\n",
+    "\n",
+    "# Compare original and reconstructed predictions\n",
+    "max_diff = np.max(np.abs(predicted - reconstructed_predictions))\n",
+    "print(f\"\\nMax difference between original and reconstructed predictions: {max_diff:.2e}\")\n",
+    "print(\"Predictions match:\", np.allclose(predicted, reconstructed_predictions))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The reconstructed model produces identical predictions to the original, confirming that the serialization round-trip preserves the model state completely."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training an RBF Model (SMT)\n",
+    "\n",
+    "The `RadialBasisFunctionModel` uses radial basis function interpolation from the SMT library. Let's train it on a more complex function and assess its accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from standard_evaluator.surrogate_models import RadialBasisFunctionModel\n",
+    "\n",
+    "# Use the Rosenbrock test evaluator (a harder, non-polynomial function)\n",
+    "rosenbrock = se.evaluators.test.Rosenbrock(num_independent=2, num_dependent=1)\n",
+    "rb_opt_problem = rosenbrock.opt_problem\n",
+    "rb_variables = rb_opt_problem.variables\n",
+    "\n",
+    "# Generate 30 training sites (Latin hypercube-like random sampling)\n",
+    "np.random.seed(123)\n",
+    "n_rb_train = 30\n",
+    "rb_train_data = {}\n",
+    "for var in rb_variables:\n",
+    "    lb, ub = var.bounds\n",
+    "    rb_train_data[var.name] = np.random.uniform(lb, ub, n_rb_train)\n",
+    "\n",
+    "rb_train_sites = pd.DataFrame(rb_train_data)\n",
+    "rosenbrock(rb_train_sites)\n",
+    "\n",
+    "# Train the RBF model\n",
+    "rbf_model = RadialBasisFunctionModel(\n",
+    "    sites=rb_train_sites,\n",
+    "    opt_problem=rb_opt_problem,\n",
+    ")\n",
+    "\n",
+    "# Generate 15 test sites\n",
+    "n_rb_test = 15\n",
+    "rb_test_data = {}\n",
+    "for var in rb_variables:\n",
+    "    lb, ub = var.bounds\n",
+    "    rb_test_data[var.name] = np.random.uniform(lb, ub, n_rb_test)\n",
+    "\n",
+    "rb_test_sites = pd.DataFrame(rb_test_data)\n",
+    "\n",
+    "# Predict with RBF model\n",
+    "rbf_model(rb_test_sites)\n",
+    "rbf_predicted = rb_test_sites[\"f\"].values.copy()\n",
+    "\n",
+    "# Get true values\n",
+    "rb_true_sites = rb_test_sites[rosenbrock.inputs].copy()\n",
+    "rosenbrock(rb_true_sites)\n",
+    "rbf_true = rb_true_sites[\"f\"].values\n",
+    "\n",
+    "# Compute RMSE\n",
+    "rmse = np.sqrt(np.mean((rbf_predicted - rbf_true) ** 2))\n",
+    "# Compute R² score\n",
+    "ss_res = np.sum((rbf_true - rbf_predicted) ** 2)\n",
+    "ss_tot = np.sum((rbf_true - np.mean(rbf_true)) ** 2)\n",
+    "r_squared = 1 - ss_res / ss_tot\n",
+    "\n",
+    "print(f\"RBF Model Accuracy on Rosenbrock function:\")\n",
+    "print(f\"  RMSE: {rmse:.4f}\")\n",
+    "print(f\"  R²:   {r_squared:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The RBF model provides good interpolation accuracy. Since RBF is an interpolation method, it passes exactly through training points and approximates well between them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Options\n",
+    "\n",
+    "Each surrogate model class defines its configurable options via a Pydantic model. Options control model behavior such as polynomial degree, regularization parameters, or basis function settings.\n",
+    "\n",
+    "- **`PolynomialModelOptions`**: `degree` (int, default=1), `coefficient_ordering` (enum)\n",
+    "- **`RadialBasisFunctionModelOptions`**: `d0` (float, default=1.0), `poly_degree` (int, default=-1), `reg` (float, default=1e-10)\n",
+    "\n",
+    "You can pass an options instance to the model constructor to override defaults. Let's see the effect of changing the polynomial degree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train a degree-1 (linear) polynomial model on the same Sphere data\n",
+    "poly_linear = PolynomialModel(\n",
+    "    sites=train_sites,\n",
+    "    options=PolynomialModelOptions(degree=1),  # Linear fit (non-default)\n",
+    "    opt_problem=opt_problem,\n",
+    ")\n",
+    "\n",
+    "# Predict at test sites\n",
+    "linear_test = pd.DataFrame(test_data)\n",
+    "poly_linear(linear_test)\n",
+    "linear_predicted = linear_test[\"f\"].values\n",
+    "\n",
+    "# Compare linear vs quadratic fit\n",
+    "options_comparison = pd.DataFrame({\n",
+    "    \"x0\": test_sites[\"x0\"],\n",
+    "    \"x1\": test_sites[\"x1\"],\n",
+    "    \"True\": true_values,\n",
+    "    \"Degree 1 (linear)\": linear_predicted,\n",
+    "    \"Degree 2 (quadratic)\": predicted,\n",
+    "})\n",
+    "print(\"Effect of polynomial degree on predictions:\")\n",
+    "options_comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The degree-1 model cannot capture the quadratic Sphere function accurately, while the degree-2 model fits it exactly. This demonstrates how the `degree` option directly affects model capability and accuracy."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/reference/components.rst
+++ b/docs/source/reference/components.rst
@@ -1,0 +1,9 @@
+Components
+==========
+
+OpenMDAO component wrappers for Standard Evaluator.
+
+.. autoclass:: standard_evaluator.components.evaluator_om_component.EvaluatorOpenMdaoComponent
+   :members:
+   :show-inheritance:
+   :special-members: __init__

--- a/docs/source/reference/data_models.rst
+++ b/docs/source/reference/data_models.rst
@@ -1,0 +1,52 @@
+Data Models
+===========
+
+This section documents the data model classes used to define optimization problems,
+evaluator interfaces, and variable types in the Standard Evaluator library.
+
+Optimization Problem
+--------------------
+
+.. autoclass:: standard_evaluator.problem.OptProblem
+   :members:
+   :show-inheritance:
+   :special-members: __init__
+
+Evaluator Info
+--------------
+
+.. autoclass:: standard_evaluator.evaluator.EvaluatorInfo
+   :members:
+   :show-inheritance:
+   :special-members: __init__
+
+Group Info
+----------
+
+.. autoclass:: standard_evaluator.evaluator.GroupInfo
+   :members:
+   :show-inheritance:
+   :special-members: __init__
+
+Variable Types
+--------------
+
+.. autoclass:: standard_evaluator.problem.FloatVariable
+   :members:
+   :show-inheritance:
+   :special-members: __init__
+
+.. autoclass:: standard_evaluator.problem.IntVariable
+   :members:
+   :show-inheritance:
+   :special-members: __init__
+
+.. autoclass:: standard_evaluator.problem.ArrayVariable
+   :members:
+   :show-inheritance:
+   :special-members: __init__
+
+.. autoclass:: standard_evaluator.problem.CategoricalVariable
+   :members:
+   :show-inheritance:
+   :special-members: __init__

--- a/docs/source/reference/decorators.rst
+++ b/docs/source/reference/decorators.rst
@@ -1,0 +1,18 @@
+Decorators
+==========
+
+Decorators that extend evaluator functionality with caching and logging capabilities.
+
+Caching
+-------
+
+.. automodule:: standard_evaluator.evaluators.decorators.cache
+   :members:
+   :show-inheritance:
+
+Site Logger
+-----------
+
+.. automodule:: standard_evaluator.evaluators.decorators.site_logger
+   :members:
+   :show-inheritance:

--- a/docs/source/reference/evaluators.rst
+++ b/docs/source/reference/evaluators.rst
@@ -1,0 +1,47 @@
+Evaluators
+==========
+
+This page documents the evaluator class hierarchy in the Standard Evaluator library.
+The abstract :class:`~standard_evaluator.evaluators.abstract_evaluator.Evaluator` base class
+defines the common API, with concrete implementations for different execution backends.
+
+Base Class
+----------
+
+.. autoclass:: standard_evaluator.evaluators.abstract_evaluator.Evaluator
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+Concrete Evaluators
+-------------------
+
+.. autoclass:: standard_evaluator.evaluators.numpy_evaluator.NumpyEvaluator
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+.. autoclass:: standard_evaluator.evaluators.executable_evaluator.ExecutableEvaluator
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+.. autoclass:: standard_evaluator.evaluators.shift_scale_evaluator.ShiftScaleEvaluator
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+.. autoclass:: standard_evaluator.evaluators.open_mdao_evaluator.OpenMDAOEvaluator
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+.. autoclass:: standard_evaluator.evaluators.excel_evaluator.ExcelEvaluator
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+.. autoclass:: standard_evaluator.evaluators.matlab_evaluator.MatlabEvaluator
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,0 +1,14 @@
+API Reference
+=============
+
+This section provides the API reference documentation for the Standard Evaluator library,
+auto-generated from source code docstrings.
+
+.. toctree::
+   :maxdepth: 1
+
+   evaluators
+   surrogate_models
+   components
+   data_models
+   decorators

--- a/docs/source/reference/surrogate_models.rst
+++ b/docs/source/reference/surrogate_models.rst
@@ -1,0 +1,76 @@
+Surrogate Models
+================
+
+This section documents the surrogate model hierarchy in the Standard Evaluator library.
+Surrogate models provide trained mathematical approximations of evaluators, supporting
+training from data, prediction, serialization, and parallel training.
+
+Base Class
+----------
+
+.. autoclass:: standard_evaluator.surrogate_models.abstract_model.SurrogateModel
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+Polynomial Model
+----------------
+
+.. autoclass:: standard_evaluator.surrogate_models.polynomial_model.PolynomialModel
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+SMT-Based Models
+----------------
+
+The following models require the ``smt`` optional dependency.
+Install with: ``pip install standard-evaluator[smt]``
+
+Radial Basis Function Model (RBFModel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: standard_evaluator.surrogate_models.smt_models.rbf_model_using_smt.RadialBasisFunctionModel
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+Inverse Distance Weighting Model (IDWModel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: standard_evaluator.surrogate_models.smt_models.idw_model_using_smt.InverseDistanceWeightingModel
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+Gradient-Enhanced Neural Networks Model (GENNModel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: standard_evaluator.surrogate_models.smt_models.genn_model_using_smt.GradientEnhancedNeuralNetworksModel
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+Least Squares Approximation Model (LSModel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: standard_evaluator.surrogate_models.smt_models.ls_model_using_smt.LeastSquaresApproximationModel
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+Regularized Minimal-Energy Tensor-Product B-Splines (RMTSModel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: standard_evaluator.surrogate_models.smt_models.rmts_model_using_smt.RegularizedMinimalEnergyTensorProductBSplines
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__
+
+Second Order Polynomial Approximation Model (SOPAModel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: standard_evaluator.surrogate_models.smt_models.sopa_model_using_smt.SecondOrderPolynomialApproximationModel
+   :members:
+   :show-inheritance:
+   :special-members: __init__, __call__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ test = [
     "coverage",
     "hypothesis",
     "numdifftools",
+    "nbformat",
+    "nbconvert",
+    "ipykernel",
 ]
 dev = [
     # Copy test requirements below

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ docs = [
     "sphinx-rtd-theme",
     "jupyter_core",
     "myst-nb",
-    
+    "smt>=2.10.1",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ docs = [
 [tool.pytest.ini_options]
 testpaths = "tests"
 minversion = "6.0"
+markers = [
+    "integration: marks tests as integration tests (may be slow)",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 # log_cli_level = "INFO"
 # log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 # log_cli_date_format = "%Y-%m-%d %H:%M:%S"

--- a/src/standard_evaluator/evaluators/test/rosenbrock.py
+++ b/src/standard_evaluator/evaluators/test/rosenbrock.py
@@ -103,7 +103,7 @@ class Rosenbrock(TestEvaluator):
 
         new_prob.description = \
         """
-        The Rosenbrock function is a continuou, nonlinear, and non-convex function used in optimization.
+        The Rosenbrock function is a continuous, nonlinear, and non-convex function used in optimization.
         It is given by
                         sum_{i=1}^{n-1} ((x_{i+1}-x_i^2)^2 + (x_i-1)^2)
                         -2 <= x_i <= 2 for i = 1,...,n.

--- a/tests/test_notebook_execution.py
+++ b/tests/test_notebook_execution.py
@@ -1,0 +1,85 @@
+"""Integration test for notebook execution correctness.
+
+**Validates: Requirements 1.7, 2.7, 3.5, 4.6, 5.5, 6.6**
+
+Execute each of the 6 new demo notebooks in a fresh kernel using nbconvert's
+ExecutePreprocessor and verify zero exceptions are raised during execution.
+
+Notebooks that require optional dependencies (e.g. smt) are skipped when those
+dependencies are not installed.
+"""
+
+from pathlib import Path
+
+import nbformat
+import pytest
+from nbconvert.preprocessors import ExecutePreprocessor
+
+# Path to the demos directory relative to the project root
+DEMOS_DIR = Path(__file__).parent.parent / "docs" / "source" / "demos"
+
+# Notebooks that only need base dependencies
+BASE_NOTEBOOKS = [
+    "evaluator_hierarchy.ipynb",
+    "openmdao_component.ipynb",
+    "array_variables.ipynb",
+    "benchmark_problems.ipynb",
+    "evaluator_interface.ipynb",
+]
+
+# Notebooks requiring optional dependencies
+SMT_NOTEBOOKS = [
+    "surrogate_models.ipynb",
+]
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("notebook_name", BASE_NOTEBOOKS)
+def test_notebook_executes_without_errors(notebook_name: str) -> None:
+    """Execute a base-dependency demo notebook and verify no exceptions.
+
+    **Validates: Requirements 1.7, 3.5, 4.6, 5.5, 6.6**
+
+    Each notebook is executed sequentially in a fresh Python 3 kernel. The test
+    fails if any cell raises a CellExecutionError during execution.
+    """
+    notebook_path = DEMOS_DIR / notebook_name
+    assert notebook_path.exists(), f"Notebook not found: {notebook_path}"
+
+    nb = nbformat.read(notebook_path, as_version=4)
+
+    ep = ExecutePreprocessor(
+        timeout=60,
+        kernel_name="python3",
+    )
+
+    # Execute the notebook in the demos directory so relative file references work
+    ep.preprocess(nb, {"metadata": {"path": str(DEMOS_DIR)}})
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("notebook_name", SMT_NOTEBOOKS)
+def test_smt_notebook_executes_without_errors(notebook_name: str) -> None:
+    """Execute an SMT-dependency demo notebook and verify no exceptions.
+
+    **Validates: Requirements 2.7**
+
+    Skipped when the smt package is not installed. Each notebook is executed
+    sequentially in a fresh Python 3 kernel.
+    """
+    pytest.importorskip("smt", reason="smt not installed, skipping surrogate model notebook test")
+
+    notebook_path = DEMOS_DIR / notebook_name
+    assert notebook_path.exists(), f"Notebook not found: {notebook_path}"
+
+    nb = nbformat.read(notebook_path, as_version=4)
+
+    ep = ExecutePreprocessor(
+        timeout=60,
+        kernel_name="python3",
+    )
+
+    # Execute the notebook in the demos directory so relative file references work
+    ep.preprocess(nb, {"metadata": {"path": str(DEMOS_DIR)}})

--- a/tests/test_notebook_structure.py
+++ b/tests/test_notebook_structure.py
@@ -1,0 +1,91 @@
+"""Property test for notebook structure invariant.
+
+**Validates: Requirements 8.1, 8.2, 8.7**
+
+For any demo notebook produced by the feature-documentation spec, the notebook
+SHALL begin with a markdown cell containing a level-1 heading, followed by an
+overview paragraph, and SHALL contain no two consecutive code cells without an
+intervening markdown cell.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+# Path to the demos directory
+_DEMOS_DIR = Path(__file__).parent.parent / "docs" / "source" / "demos"
+
+# The 6 new demo notebooks produced by this feature
+_NEW_NOTEBOOKS = [
+    "evaluator_hierarchy.ipynb",
+    "surrogate_models.ipynb",
+    "openmdao_component.ipynb",
+    "array_variables.ipynb",
+    "benchmark_problems.ipynb",
+    "evaluator_interface.ipynb",
+]
+
+
+def _load_notebook(filename: str) -> dict:
+    """Load and parse a notebook JSON file."""
+    with open(_DEMOS_DIR / filename, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("notebook_name", _NEW_NOTEBOOKS)
+def test_first_cell_is_markdown_with_level1_heading(notebook_name):
+    """Each notebook starts with a markdown cell containing a level-1 heading.
+
+    **Validates: Requirements 8.1**
+    """
+    nb = _load_notebook(notebook_name)
+    cells = nb["cells"]
+
+    assert len(cells) > 0, f"{notebook_name} has no cells"
+
+    first_cell = cells[0]
+    assert first_cell["cell_type"] == "markdown", (
+        f"{notebook_name}: first cell is '{first_cell['cell_type']}', expected 'markdown'"
+    )
+
+    source = "".join(first_cell["source"]) if isinstance(first_cell["source"], list) else first_cell["source"]
+    lines = source.split("\n")
+    assert any(line.startswith("# ") for line in lines), (
+        f"{notebook_name}: first markdown cell has no level-1 heading (no line starting with '# ')"
+    )
+
+
+@pytest.mark.parametrize("notebook_name", _NEW_NOTEBOOKS)
+def test_first_cell_has_overview_paragraph(notebook_name):
+    """Each notebook has an overview paragraph in the first markdown cell.
+
+    **Validates: Requirements 8.2**
+    """
+    nb = _load_notebook(notebook_name)
+    first_cell = nb["cells"][0]
+
+    source = "".join(first_cell["source"]) if isinstance(first_cell["source"], list) else first_cell["source"]
+    lines = source.strip().split("\n")
+
+    # There must be text beyond the heading line
+    non_heading_lines = [line for line in lines if line.strip() and not line.startswith("# ")]
+    assert len(non_heading_lines) > 0, (
+        f"{notebook_name}: first cell has no overview paragraph beyond the heading"
+    )
+
+
+@pytest.mark.parametrize("notebook_name", _NEW_NOTEBOOKS)
+def test_no_consecutive_code_cells(notebook_name):
+    """No two adjacent cells are both code cells.
+
+    **Validates: Requirements 8.7**
+    """
+    nb = _load_notebook(notebook_name)
+    cells = nb["cells"]
+
+    for i in range(len(cells) - 1):
+        if cells[i]["cell_type"] == "code" and cells[i + 1]["cell_type"] == "code":
+            pytest.fail(
+                f"{notebook_name}: consecutive code cells at positions {i} and {i + 1}"
+            )

--- a/tests/test_sphinx_build.py
+++ b/tests/test_sphinx_build.py
@@ -1,0 +1,136 @@
+"""Integration test for Sphinx build completeness.
+
+Feature: feature-documentation
+Property 2: Build Completeness
+
+**Validates: Requirements 7.3, 9.7**
+
+Verifies that the Sphinx documentation build completes successfully and that
+the new demo notebooks and API reference pages produce HTML output. The build
+runs without the -W flag since pre-existing orphan notebooks in docs/source/demos/
+(e.g. design_space_exploration.ipynb, group_demo.md) produce toctree warnings
+that are unrelated to our changes.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Skip all tests in this module if sphinx is not installed
+sphinx = pytest.importorskip("sphinx", reason="Sphinx is required for documentation build tests")
+
+# Project root directory
+_PROJECT_ROOT = Path(__file__).parent.parent
+
+# Docs source and build directories
+_DOCS_SOURCE = _PROJECT_ROOT / "docs" / "source"
+_DOCS_BUILD = _PROJECT_ROOT / "docs" / "build" / "test_html"
+
+# The 6 new demo notebooks that should generate HTML pages
+_NEW_DEMO_PAGES = [
+    "evaluator_hierarchy",
+    "surrogate_models",
+    "openmdao_component",
+    "array_variables",
+    "benchmark_problems",
+    "evaluator_interface",
+]
+
+# API reference pages that should be generated
+_REFERENCE_PAGES = [
+    "evaluators",
+    "surrogate_models",
+    "components",
+    "data_models",
+    "decorators",
+]
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestSphinxBuildCompleteness:
+    """Integration tests verifying Sphinx documentation builds without errors.
+
+    **Validates: Requirements 7.3, 9.7**
+    """
+
+    def test_sphinx_build_succeeds(self):
+        """Sphinx build completes successfully (return code 0).
+
+        Runs sphinx-build without -W so that pre-existing orphan-document
+        warnings from legacy notebooks do not cause a failure. We only
+        verify that the build itself succeeds.
+
+        **Validates: Requirements 7.3, 9.7**
+        """
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "sphinx",
+                "-b",
+                "html",
+                str(_DOCS_SOURCE),
+                str(_DOCS_BUILD),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(_PROJECT_ROOT),
+            timeout=600,  # 10-minute timeout for full build with notebook execution
+            check=False,  # We check returncode manually for better error messages
+        )
+
+        assert result.returncode == 0, (
+            f"Sphinx build failed with return code {result.returncode}.\n"
+            f"STDOUT:\n{result.stdout[-2000:] if len(result.stdout) > 2000 else result.stdout}\n"
+            f"STDERR:\n{result.stderr[-2000:] if len(result.stderr) > 2000 else result.stderr}"
+        )
+
+    def test_demo_html_files_generated(self):
+        """Verify HTML files are generated for all 6 new demo notebooks.
+
+        **Validates: Requirements 7.3**
+        """
+        # Only check if build output exists (test_sphinx_build_succeeds
+        # must run first to produce output)
+        demos_build_dir = _DOCS_BUILD / "demos"
+        if not demos_build_dir.exists():
+            pytest.skip(
+                "Build output not found. Run test_sphinx_build_succeeds first."
+            )
+
+        missing_pages = []
+        for page_name in _NEW_DEMO_PAGES:
+            html_file = demos_build_dir / f"{page_name}.html"
+            if not html_file.exists():
+                missing_pages.append(page_name)
+
+        assert not missing_pages, (
+            f"Missing HTML files for demo pages: {missing_pages}. "
+            f"Expected files in {demos_build_dir}"
+        )
+
+    def test_reference_html_files_generated(self):
+        """Verify HTML files are generated for all API reference pages.
+
+        **Validates: Requirements 9.7**
+        """
+        # Only check if build output exists
+        reference_build_dir = _DOCS_BUILD / "reference"
+        if not reference_build_dir.exists():
+            pytest.skip(
+                "Build output not found. Run test_sphinx_build_succeeds first."
+            )
+
+        missing_pages = []
+        for page_name in _REFERENCE_PAGES:
+            html_file = reference_build_dir / f"{page_name}.html"
+            if not html_file.exists():
+                missing_pages.append(page_name)
+
+        assert not missing_pages, (
+            f"Missing HTML files for reference pages: {missing_pages}. "
+            f"Expected files in {reference_build_dir}"
+        )


### PR DESCRIPTION
- 6 demo notebooks: evaluator hierarchy, surrogate models, OpenMDAO component, array variables, benchmark problems, evaluator interface
- API reference section with autoclass/automodule directives for all public classes
- Updated demos index.rst toctree
- Notebook structure, execution, and Sphinx build validation tests
- Cleaned up ~2000 generated OpenMDAO output files and optproblem*.json artifacts
- Updated .gitignore to prevent re-accumulation of generated artifacts
- Strengthened python-environment steering file with explicit rules
- Added pytest integration/slow markers to pyproject.toml